### PR TITLE
chore: apply language rule to Claude config files and update yml settings

### DIFF
--- a/.claude/agents/deploy.md
+++ b/.claude/agents/deploy.md
@@ -1,0 +1,83 @@
+---
+name: deploy
+description: feature 브랜치의 변경사항을 빌드/테스트 → 커밋 → PR → CI 대기 → 머지 → 배포 확인 → 브랜치 삭제까지 자동화한다.
+allowed-tools: Bash(./gradlew *) Bash(git *) Bash(gh *) Bash(bash *) Bash(sleep *) Read Glob
+---
+
+# Deploy Agent
+
+> **Language rule**: Write all files and code in English. Always respond to the user in Korean.
+
+현재 feature 브랜치의 변경사항을 배포 파이프라인 끝까지 자동 처리한다.
+스크립트는 모두 `.claude/skills/deploy/scripts/` 에 있다.
+
+## 사전 확인
+
+현재 브랜치와 이슈 번호를 파악한다.
+
+```bash
+git branch --show-current
+```
+
+브랜치명이 `feature/{N}` 형태여야 한다. N이 이슈 번호다.
+
+## Step 1: 빌드 & 테스트
+
+```bash
+bash .claude/skills/deploy/scripts/build-and-test.sh
+```
+
+실패 시 `references/error-handling.md`를 참고해 원인을 분석하고 코드를 수정한다.
+3회 반복 후에도 실패하면 사용자에게 보고하고 중단한다.
+
+## Step 2: 커밋 & 푸시
+
+커밋 설명은 prompt에서 전달받은 내용을 사용한다. 없으면 변경된 파일을 보고 적절히 작성한다.
+`references/commit-conventions.md`를 참고해 type을 결정한다.
+
+```bash
+bash .claude/skills/deploy/scripts/commit-and-push.sh {N} "{커밋 설명}" {type}
+```
+
+## Step 3: PR 생성
+
+`assets/pr-template.md`를 참고해 PR 제목과 본문을 작성한다.
+
+```bash
+bash .claude/skills/deploy/scripts/create-pr.sh {N} "{PR 제목}" "{PR 본문}"
+```
+
+출력에서 PR 번호를 추출해 이후 단계에 사용한다.
+
+## Step 4: CI 대기
+
+```bash
+bash .claude/skills/deploy/scripts/wait-for-ci.sh {PR번호}
+```
+
+CI 실패 시 `references/error-handling.md`의 "CI 실패" 섹션을 참고한다.
+원인 수정 후 `commit-and-push.sh`로 재푸시하면 CI가 자동 재트리거된다.
+수정 커밋은 type을 `fix`로 지정한다.
+
+## Step 5: 머지 & 배포
+
+```bash
+bash .claude/skills/deploy/scripts/merge-and-deploy.sh {PR번호}
+```
+
+배포 실패 시 인프라 레벨 이슈가 많으므로 원인을 분석해 사용자에게 보고하고 중단한다.
+
+## Step 6: 브랜치 정리
+
+```bash
+bash .claude/skills/deploy/scripts/cleanup-branch.sh {N}
+```
+
+## 완료 보고
+
+```
+PR: #{PR번호}
+배포: 성공
+브랜치: feature/{N} 삭제 완료
+현재 브랜치: develop
+```

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,73 +1,15 @@
 ---
 name: deploy
 description: feature 브랜치에서 빌드/테스트 → 커밋 → PR → CI → 머지 → 배포 확인 → 브랜치 삭제까지 배포 파이프라인을 자동화한다. 사용자가 "커밋해줘", "배포해줘", "PR 올려줘", "deploy" 라고 하면 실행.
-allowed-tools: Bash(./gradlew *) Bash(git *) Bash(gh *) Bash(curl *) Bash(bash *) Bash(chmod *) Read Grep Glob Edit
+allowed-tools: Agent
 argument-hint: "[커밋 설명]"
 ---
 
-# Deploy Pipeline
+# Deploy
 
-현재 feature 브랜치의 변경사항을 배포한다.
-각 단계가 실패하면 `references/error-handling.md`를 참고해 최대 3회 분석·수정 후 재시도한다.
-3회 초과 시 사용자에게 보고하고 중단한다.
+> **Language rule**: Write all files and code in English. Always respond to the user in Korean.
 
-## 사전 준비: 이슈 번호 확인
+`deploy` subagent를 생성하여 현재 feature 브랜치의 변경사항을 배포한다.
 
-현재 브랜치 이름(`feature/{N}`)에서 이슈 번호(N)를 추출한다.
-
-```bash
-git branch --show-current
-```
-
-브랜치가 `feature/{N}` 형식이 아니면 사용자에게 확인 후 중단한다.
-
-## Step 1: 빌드 & 테스트
-
-```bash
-bash scripts/build-and-test.sh
-```
-
-실패 시 `references/error-handling.md` → "빌드/테스트 실패" 섹션 참고.
-
-## Step 2: 커밋 & 푸시
-
-`references/commit-conventions.md`를 참고해 커밋 메시지를 작성한다.
-
-```bash
-bash scripts/commit-and-push.sh {N} "{커밋 설명}"
-```
-
-## Step 3: PR 생성
-
-`assets/pr-template.md`를 읽어 PR 본문을 채운 후 실행한다.
-
-```bash
-bash scripts/create-pr.sh {N} "{PR 제목}" "{PR 본문}"
-```
-
-반환된 PR 번호를 기록한다.
-
-## Step 4: CI 통과 대기
-
-```bash
-bash scripts/wait-for-ci.sh {PR번호}
-```
-
-실패 시 `references/error-handling.md` → "CI 실패" 섹션 참고.
-
-## Step 5: PR 머지 & 배포 대기
-
-```bash
-bash scripts/merge-and-deploy.sh {PR번호}
-```
-
-## Step 6: 헬스체크 & 브랜치 정리
-
-```bash
-bash scripts/health-check.sh
-bash scripts/cleanup-branch.sh {N}
-```
-
-## 완료 보고
-
-`assets/report-template.md` 형식으로 결과를 사용자에게 요약 보고한다.
+Agent tool을 사용해 subagent_type="deploy"로 spawn하고, 커밋 설명을 prompt에 포함한다.
+subagent의 출력 결과를 그대로 사용자에게 전달한다.

--- a/.claude/skills/feature-dev/SKILL.md
+++ b/.claude/skills/feature-dev/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: feature-dev
-description: 이 프로젝트의 아키텍처 규칙을 따라 새 기능을 구현한다. 이슈 생성 → 브랜치 → 코드 구현 → 테스트 작성 → 빌드 검증까지 수행. 사용자가 "~API 만들어줘", "~기능 구현해줘" 라고 하면 실행.
+description: 이 프로젝트의 아키텍처 규칙을 따라 새 기능을 구현한다. 이슈 확인/생성 → 브랜치 → 코드 구현까지 수행. 테스트·빌드는 별도 명령으로 분리. 사용자가 "~API 만들어줘", "~기능 구현해줘" 라고 하면 실행.
 allowed-tools: Bash(./gradlew *) Bash(git *) Bash(gh *) Bash(bash *) Read Grep Glob Edit Write
 argument-hint: "[구현할 기능 설명]"
 ---
 
 # Feature Dev Pipeline
 
+> **Language rule**: Write all files and code in English. Always respond to the user in Korean.
+
+> **금지**: 이 스킬은 테스트 코드를 절대 작성하지 않는다. `src/test/` 하위 파일을 건드리지 않는다. 테스트는 `/test-write` 스킬이 전담한다.
+
 사용자가 전달한 기능 설명을 기반으로 아래 단계를 순서대로 실행한다.
 
-## Step 0: 이슈 생성
+## Step 0: 이슈 확인 및 생성
 
-`assets/issue-template.md`가 있으면 참고, 없으면 아래 형식으로 이슈 제목·본문을 직접 작성한다.
+먼저 기존 이슈 중 관련된 것이 있는지 확인한다.
+
+```bash
+gh issue list --state open --limit 50
+```
+
+유사한 이슈가 있으면 사용자에게 보여주고 해당 이슈를 재사용할지 새로 만들지 확인한다.
+새로 만드는 경우 `assets/issue-template.md`가 있으면 참고, 없으면 아래 형식으로 작성한다.
 
 ```bash
 bash scripts/create-issue.sh "{이슈 제목}" "{이슈 본문}"
@@ -35,7 +46,7 @@ bash scripts/setup-branch.sh {N}
 
 ## Step 3: 구현
 
-`references/architecture.md`와 `references/patterns.md`를 읽고 아래 순서로 구현한다.
+`references/architecture.md`를 읽고 아래 순서로 구현한다.
 
 ### 3-1. DataAccess 계층
 - Entity, Repository (필요 시 QueryDSL)
@@ -45,7 +56,7 @@ bash scripts/setup-branch.sh {N}
 - 역할 판단 기준 → `references/architecture.md`
 
 ### 3-3. Request & Command 결정
-- **Command 사용 여부** → `references/patterns.md` 의 "Command 사용 판단" 섹션 반드시 참고
+- `references/patterns.md`를 읽고 "Command 사용 판단" 섹션에 따라 결정
 
 ### 3-4. Business(Service) 계층
 - 흐름 오케스트레이션만 담당. Repository 직접 참조 금지.
@@ -57,21 +68,18 @@ bash scripts/setup-branch.sh {N}
 ### 3-6. ErrorType / ErrorCode 추가
 - `references/error-codes.md` 에서 다음 사용 가능한 코드 번호 확인 후 추가
 
-## Step 4: 테스트 작성
+## Step 4: 스냅샷 문서 갱신
 
-`references/test-conventions.md`를 읽고 아래를 작성한다.
+구현으로 인해 변경된 내용을 `.claude/skills/feature-dev/references/snapshot.md` 에 반영한다.
 
-- **단위 테스트**: Business 계층 + Implement 계층 각 1개 이상
-- **Fixture 클래스**: 테스트 데이터 상수·팩토리 메서드 정의
-- 통합 테스트는 DB 연동이 필요한 경우에만 작성
+- 새 API 엔드포인트 → "API 엔드포인트" 테이블에 추가
+- 새 Entity → "엔티티 목록" 테이블에 추가
+- 새 도메인 → "도메인별 패키지 현황" 테이블에 추가
+- 해결된 기술 부채 → "알려진 기술 부채" 테이블에서 제거
+- 새롭게 발견한 기술 부채 → "알려진 기술 부채" 테이블에 추가
+- 파일 상단 `마지막 업데이트` 날짜를 오늘 날짜로 수정
 
-## Step 5: 로컬 빌드 & 테스트 검증
-
-```bash
-./gradlew clean build
-```
-
-실패 시 에러 로그를 분석해 코드를 수정한다. 3회 반복 후에도 실패하면 사용자에게 보고하고 중단한다.
+변경 사항이 없으면 이 단계를 건너뛴다.
 
 ## 완료 보고
 
@@ -82,7 +90,9 @@ bash scripts/setup-branch.sh {N}
 브랜치: feature/{N}
 구현 항목:
   - [계층별 생성/수정 파일 목록]
-테스트:
-  - [작성한 테스트 클래스 목록]
-다음 단계: /deploy 로 배포 진행
+다음 단계: 테스트·빌드 준비되면 "테스트 작성해줘" 또는 /deploy 로 배포 진행
 ```
+
+---
+
+테스트 코드 작성·빌드 검증은 `/test-write` 스킬을 사용한다.

--- a/.claude/skills/feature-dev/references/architecture.md
+++ b/.claude/skills/feature-dev/references/architecture.md
@@ -15,12 +15,31 @@ Controller → Business(Service) → Implement → DataAccess(JPA/QueryDSL)
 |--------|------|
 | `auth` | 로컬/OAuth2 인증, 토큰 발급 |
 | `care` | 케어 초대(CareInvitation), 케어 관계(CareRelationship) |
+| `device` | Device Token 발급·검증 (GPS 전용 장기 인증) |
 | `member` | 회원 프로필, 전화번호 인증 연동 |
 | `sms` | CoolSMS 기반 인증코드 발송/검증 |
-| `security` | JWT 필터, JwtGenerator, JwtValidator |
+| `security` | JWT 필터, DeviceTokenAuthFilter, JwtGenerator, JwtValidator |
 | `support` | AppException, ErrorType, ErrorCode, ApiResponse |
 | `common` | AOP, BaseEntity, 글로벌 예외 핸들러 |
 | `config` | Security, Redis, Mapper, Swagger 설정 |
+
+## 도메인 내부 패키지 구조
+
+```
+{domain}/
+├── business/       # Service — 유즈케이스 오케스트레이션
+├── controller/     # REST Controller, Request/Response
+│   ├── request/
+│   └── response/
+├── dataaccess/     # Entity, Repository
+│   ├── entity/
+│   └── repository/
+├── implement/      # Reader, Writer, Manager, Validator, ...
+└── vo/             # 도메인 객체 (불변 record) — 레이어 간 흐름 객체
+```
+
+`vo/`는 해당 도메인의 핵심 성질을 담는 불변 record다. business DTO가 아니라 도메인 개념 자체를 표현한다.
+entity → VO 변환은 VO의 `from()` 팩토리 메서드에서 담당하며, implement 계층(Reader 등)이 변환해 반환한다.
 
 ## Implement 계층 역할 분리
 
@@ -41,13 +60,24 @@ Controller → Business(Service) → Implement → DataAccess(JPA/QueryDSL)
 
 ## 인증 흐름
 
+### JWT (보호자/일반 API)
 ```
 Authorization: Bearer {accessToken}
 → JwtAuthenticationFilter (memberKey를 SecurityContext에 저장)
 → @AuthMember String memberKey (Controller 파라미터 주입)
 ```
-
 Access Token → 응답 바디, Refresh Token → HttpOnly Cookie
+
+### Device Token (GPS 전용, WARD 백그라운드 앱)
+```
+Authorization: Device {deviceToken}
+→ DeviceTokenAuthFilter (wardKey를 SecurityContext에 저장)
+→ @AuthMember String memberKey (기존 LocationController 그대로 사용)
+```
+- `POST /api/v1/location/gps` 경로에서만 작동
+- JwtAuthenticationFilter는 이 경로를 건너뜀 (shouldNotFilter)
+- 발급: `POST /api/v1/device/token` (JWT 인증, WARD 전용, 최초 1회)
+- 재발급: 동일 엔드포인트 재호출 → 기존 토큰 교체
 
 ## 논리 삭제
 
@@ -64,3 +94,11 @@ public class Entity extends BaseEntity { ... }
 
 - 회원: `memberKey` (UUID) — DB PK 외부 노출 절대 금지
 - CareInvitation: `requestKey` (UUID)
+
+## 인덱스 규칙
+
+`@Table(indexes = {...})` 금지. 인덱스는 별도 DDL로 관리하며 Entity에 TODO 주석으로 표시한다 (CLAUDE.md 참고).
+
+---
+
+> 현재 API·엔티티·기술 부채 목록은 `snapshot.md` 참고.

--- a/.claude/skills/feature-dev/references/patterns.md
+++ b/.claude/skills/feature-dev/references/patterns.md
@@ -97,6 +97,42 @@ public record PhoneNumber(String value) {
 }
 ```
 
+## 도메인 VO — 레이어 간 흐름 객체
+
+Business 패키지에 데이터 전달 전용 DTO(예: `GpsHistoryInfo`)를 만들지 않는다.
+대신 해당 도메인의 성질을 담은 VO를 `vo` 패키지에 두고, implement → business → controller 전 레이어에서 동일하게 사용한다.
+
+**규칙**
+- 위치: `{domain}/vo/`
+- 형식: `record` (불변)
+- entity → VO 변환은 VO의 `from(Entity entity)` 팩토리 메서드에서 담당
+- Reader 계층이 entity를 VO로 변환해 반환 (Service는 entity를 직접 다루지 않음)
+
+```java
+// vo/Gps.java — GPS 도메인의 성질(좌표 + 시각)을 캡슐화
+public record Gps(double lat, double lng, LocalDateTime recordedAt) {
+    public static Gps from(GpsHistory entity) {
+        return new Gps(entity.getLatitude(), entity.getLongitude(), entity.getRecordedAt());
+    }
+}
+
+// implement/GpsHistoryReader.java — entity → VO 변환 책임
+public List<Gps> findByWardKeyAndDate(String wardMemberKey, LocalDate date) {
+    return repository.findByWardKeyAndDate(wardMemberKey, date)
+            .stream()
+            .map(Gps::from)
+            .toList();
+}
+
+// business/LocationService.java — VO를 그대로 사용
+public List<Gps> getHistory(String caregiverKey, String wardKey, LocalDate date) {
+    locationValidator.validateCaregiverAccess(caregiverKey, wardKey);
+    return gpsHistoryReader.findByWardKeyAndDate(wardKey, date);
+}
+```
+
+**금지**: `business/` 패키지에 데이터 전달용 record(예: `GpsHistoryInfo`) 생성 금지.
+
 ## Request 패턴
 
 - `record` 사용
@@ -105,13 +141,8 @@ public record PhoneNumber(String value) {
 
 ## ApiResponse 반환
 
-```java
-// 데이터 있음
-return ResponseEntity.ok(ApiResponse.success(responseDto));
-
-// 데이터 없음 (201 Created 등)
-return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success());
-```
+- 데이터 있음: `ResponseEntity.ok(ApiResponse.success(responseDto))`
+- 데이터 없음: `ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success())`
 
 ## CareRole / MemberRole
 

--- a/.claude/skills/feature-dev/references/snapshot.md
+++ b/.claude/skills/feature-dev/references/snapshot.md
@@ -1,0 +1,84 @@
+# 프로젝트 스냅샷
+
+> 마지막 업데이트: 2026-04-25. 기능 추가·수정 시 해당 섹션을 갱신한다.
+
+## 도메인별 패키지 현황
+
+| 도메인 | 주요 Service | 주요 Implement |
+|--------|-------------|---------------|
+| `auth` | LocalAuthService, OAuthService, TokenRefreshService | LocalAuthAuthenticator, TokenIssuer, RefreshTokenReader/Writer, OAuthManager |
+| `care` | CareInvitationService, CareRelationshipService | CareInvitationManager, CareInvitationReader/Writer, CareRelationshipValidator, SqsPublisher(전략패턴) |
+| `device` | DeviceTokenService | — (Repository 직접 사용) |
+| `location` | LocationService | GpsHistoryReader/Writer, GpsLatestCacheReader/Writer, SseEmitterManager, LocationValidator |
+| `member` | MemberService | MemberReader/Writer/Validator |
+| `sms` | PhoneVerificationService | SmsClient, SmsCodeGenerator, PhoneVerificationReader/Writer |
+
+## API 엔드포인트
+
+| 도메인 | Method | Path | 설명 |
+|--------|--------|------|------|
+| Auth | POST | `/api/v1/auth/sign-up` | 로컬 회원가입 |
+| Auth | POST | `/api/v1/auth/sign-in` | 로컬 로그인 |
+| Auth | POST | `/api/v1/auth/oauth/sign-in` | OAuth 로그인 (카카오/네이버) |
+| Auth | POST | `/api/v1/auth/oauth/sign-up` | OAuth 회원가입 |
+| Auth | POST | `/api/v1/auth/token/refresh` | 토큰 갱신 |
+| Auth | GET | `/api/v1/auth/email/mask` | 이메일 마스킹 조회 |
+| Auth | PATCH | `/api/v1/auth/password` | 비밀번호 변경 |
+| Care | POST | `/api/v1/care/requests/ward` | 보호대상자 추가 요청 (GUARDIAN) |
+| Care | POST | `/api/v1/care/requests/manager` | 관리자 추가 요청 |
+| Care | POST | `/api/v1/care/requests/guardian` | 보호자 추가 요청 |
+| Care | GET | `/api/v1/care/requests/received` | 받은 케어 요청 목록 |
+| Care | PATCH | `/api/v1/care/requests/{key}/accept` | 케어 요청 수락 |
+| Care | PATCH | `/api/v1/care/requests/{key}/reject` | 케어 요청 거절 |
+| Care | GET | `/api/v1/care/wards` | 내 보호대상자 목록 |
+| Care | GET | `/api/v1/care/wards/{wardKey}/caregivers` | 보호자/관리자 목록 |
+| Device | POST | `/api/v1/device/token` | Device Token 발급 (WARD, JWT 인증) |
+| Location | POST | `/api/v1/location/gps` | GPS 좌표 전송 (WARD, Device Token 인증) |
+| Location | GET | `/api/v1/location/stream/{wardKey}` | SSE 실시간 위치 스트림 (GUARDIAN) |
+| Location | GET | `/api/v1/location/history/{wardKey}` | 날짜별 이동 경로 히스토리 |
+| Member | GET/PATCH | `/api/v1/member/...` | 회원 정보 조회/수정 |
+| SMS | POST | `/api/v1/sms/verification/send` | SMS 인증코드 발송 |
+| SMS | POST | `/api/v1/sms/verification/verify` | SMS 인증코드 검증 |
+
+## 엔티티 목록
+
+| Entity | Table | 주요 필드 |
+|--------|-------|---------|
+| Member | members | memberKey(UUID), role(GUARDIAN/WARD), name, phone |
+| LocalAuth | local_auths | account, encodedPassword, memberKey |
+| OAuth | oauths | provider(KAKAO/NAVER), providerId, memberKey |
+| LoginHistory | login_histories | memberKey, ip, loginAt |
+| CareRelationship | care_relationships | caregiverKey, wardKey, role(GUARDIAN/MANAGER) |
+| CareInvitation | care_invitations | inviterKey, receiverKey, wardKey, status(PENDING/ACCEPTED/REJECTED/EXPIRED), createdAt |
+| GpsHistory | gps_histories | wardMemberKey, latitude, longitude, recordedAt |
+| WardDeviceToken | ward_device_tokens | wardKey(UUID, UNIQUE), token(UUID, UNIQUE), createdAt, expiresAt |
+| MembersTermsAgreement | members_terms_agreements | memberKey, agreedAt |
+
+## Redis 키 구조
+
+```
+refresh:{memberKey}       RefreshToken          TTL: 7일
+sms:{phone}               SMS 인증코드          TTL: 3분
+gps:latest:{memberKey}    GPS 최신 위치         TTL: 5분  { lat, lng, timestamp }
+```
+
+## SqsPublisher 전략 패턴
+
+- `SqsPublisher` (interface) — care.implement
+- `AwsSqsPublisher` (AWS SQS 실제 구현, prod 프로파일)
+- `NoOpSqsPublisher` (로컬/테스트용 no-op, local/test 프로파일)
+
+---
+
+## 알려진 기술 부채
+
+> 개선 구현 시 해당 항목을 제거한다.
+
+| # | 항목 | 위치 | 설명 |
+|---|------|------|------|
+| 1 | SSE emitter 메모리 누수 위험 | `SseEmitterManager` | 부하 시 emitter 미제거 → heap 증가. broadcast 중 IOException 외 예외 케이스 누락 가능 |
+| 2 | AFTER_COMMIT 실패 무시 | `GpsEventHandler` | DB 저장 성공 → Redis/SSE 실패 시 재시도 없음. Outbox 패턴 미적용 |
+| 3 | GPS 히스토리 인덱스 미실행 | `GpsHistory` entity | `ward_member_key + recorded_at` 복합 인덱스 TODO 주석만 있고 DDL 미실행 |
+| 4 | SSE 구독자 수 무제한 | `SseEmitterManager` | wardKey당 emitter 수 제한 없음 |
+| 5 | CareInvitation 만료 정리 배치 없음 | `CareInvitation` | PENDING 만료건 DB에 잔류, 주기적 정리 미구현 |
+| 6 | Device Token 검증 DB 직조회 | `DeviceTokenAuthFilter` | GPS 수신마다 `WardDeviceTokenRepository.findByToken()` DB 조회. Redis 캐싱(`device-token:{token}` → wardMemberKey, TTL 24h)으로 개선 가능. 단, 재발급(`reissue()`) 시 구 토큰 캐시 명시적 삭제 필요 — 트러블슈팅 비교 후 적용 결정 |

--- a/.claude/skills/test-write/SKILL.md
+++ b/.claude/skills/test-write/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: test-write
+description: 구현된 기능에 대한 테스트 코드를 작성하고 로컬 빌드로 검증한다. 사용자가 "테스트 작성해줘", "테스트 코드 짜줘" 라고 하면 실행.
+allowed-tools: Bash(./gradlew *) Bash(git *) Read Grep Glob Edit Write
+argument-hint: "[테스트 대상 기능 또는 클래스명]"
+---
+
+# Test Write Pipeline
+
+> **Language rule**: Write all files and code in English. Always respond to the user in Korean.
+
+feature-dev 스킬이 구현한 코드를 기반으로 테스트를 작성한다.  
+`src/main/` 코드는 수정하지 않는다.
+
+## Step 1: 대상 파악
+
+현재 브랜치의 변경 파일을 확인해 테스트 대상을 파악한다.
+
+```bash
+git diff --name-only develop...HEAD -- 'src/main/**'
+```
+
+각 파일의 역할(Implement / Business / Controller)을 확인한다.
+
+## Step 2: 기존 테스트 컨벤션 확인
+
+```bash
+find src/test -name "*.java" | head -10
+```
+
+기존 테스트 파일 중 1~2개를 읽어 Given-When-Then 구조, Mock 방식, Fixture 패턴을 파악한다.
+
+## Step 3: 테스트 작성
+
+### 단위 테스트 (Implement 계층)
+- 대상: `*Reader`, `*Writer`, `*Manager`, `*Validator` 등
+- Mock 대상: 외부 의존성(Repository, 외부 서비스)만
+- Given-When-Then 구조 준수
+- 파일 위치: `src/test/java/com/recaring/{domain}/implement/`
+
+### 단위 테스트 (Business 계층)
+- 대상: `*Service`
+- Mock 대상: Implement 계층 클래스 전체
+- 파일 위치: `src/test/java/com/recaring/{domain}/`
+
+### Fixture 클래스
+- 테스트 데이터 상수·팩토리 메서드를 `*Fixture` 클래스에 정의
+- 동일 도메인의 기존 Fixture가 있으면 메서드를 추가한다 (새 파일 생성 금지)
+- 파일 위치: `src/test/java/com/recaring/{domain}/`
+
+### 통합 테스트
+- DB 연동이 필요한 경우에만 작성
+- `@Tag("integration")` 붙이기
+
+## Step 4: 빌드 & 검증
+
+```bash
+./gradlew test 2>&1 | tail -80
+```
+
+실패 시 에러 로그를 분석해 수정한다. 3회 반복 후에도 실패하면 사용자에게 보고하고 중단한다.
+
+## 완료 보고
+
+```
+작성한 테스트:
+  - [파일명 및 테스트 메서드 목록]
+빌드 결과: 성공 / 실패
+다음 단계: /deploy 로 배포 진행
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,21 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Language Rule
+
+**Write all files and code in English.** (variable names, class names, method names, comments, commit messages, PR descriptions, etc.)  
+**Always respond to the user in Korean.**
+
+## 프로젝트 분석 지침
+
+개선점, 아키텍처 조언, 전체 프로젝트 분석 요청 시 → **절대로** 전체 코드베이스를 스캔하지 않는다. 아래 파일을 읽는 것으로 충분하다. Explore 에이전트를 쓸 때도 이 파일들만 읽도록 프롬프트에 명시한다.
+
+- **인프라/시스템 구조**: `docs/architecture.md`
+- **코드 아키텍처 규칙**: `.claude/skills/feature-dev/references/architecture.md`
+- **API·엔티티·기술 부채 현황**: `.claude/skills/feature-dev/references/snapshot.md`
+
+기능 구현 후 새 API·엔티티·알려진 이슈가 생기면 `.claude/skills/feature-dev/references/snapshot.md`의 해당 섹션을 함께 갱신한다.
+
 ## 빌드 및 실행 명령어
 
 ```bash
@@ -18,3 +33,23 @@ docker compose -f docker-compose-local.yml up -d  # 인프라 (PostgreSQL 16, Re
 ## 스택
 
 Spring Boot 4.0.3 · Java 21 · PostgreSQL 16 · Redis 7 · QueryDSL 7 · JWT (jjwt 0.12) · CoolSMS
+
+## 로깅 규칙
+
+로그 메시지는 `[카테고리 : 상세내용]` 형식으로 작성한다.
+
+```java
+// 형식: [카테고리 : 상세내용]: 추가 정보
+log.info("[GPS 수신 : 저장 완료]: wardKey={}", wardKey);
+log.warn("[SSE 이벤트 : 전송 실패]: wardKey={} | error={}", wardKey, e.getMessage());
+log.error("[Redis 캐시 : 직렬화 실패]: wardKey={} | error={}", wardKey, e.getMessage());
+```
+
+- 카테고리: 도메인 또는 컴포넌트명 (예: `GPS 수신`, `SSE 이벤트`, `Redis 캐시`)
+- 상세내용: 동작 결과 (예: `저장 완료`, `전송 실패`, `연결 종료`)
+- 추가 정보: `key=value | key=value` 형식으로 컨텍스트 추가
+- 레벨 선택: 정상 흐름 → `info`, 비즈니스 예외 → `warn`, 시스템 오류 → `error`, 디버그 → `debug`
+
+## 인덱스 규칙
+
+Entity `@Table`의 `indexes` 속성을 사용하지 않는다. 인덱스는 별도 DDL 쿼리로 관리하며, 필요한 위치에 TODO 주석으로 표시한다.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,255 @@
+# re-caring 전체 아키텍처
+
+> 작성일: 2026-04-19
+> 대상 규모: 사용자 100명 (MVP)
+
+---
+
+## 인프라 구성 요약
+
+| 항목 | 선택 | 이유 |
+|------|------|------|
+| **런치 타입** | ECS EC2 Launch Type | 24시간 상시 실행 → Fargate보다 EC2 고정 비용이 유리 |
+| **EC2 스펙** | t3.medium (4GB RAM) | 전체 컨테이너 합산 ~2.5GB, 여유 1GB 이상 |
+| **SSL** | nginx + certbot | ALB($16/월) 대신 Let's Encrypt 무료 인증서 자동 갱신 |
+| **GPS 파이프라인** | SQS 직접 발행 | 단일 Consumer(LLM)이므로 SNS fan-out 불필요 |
+| **Redis 영속성** | ECS + EFS AOF | ElastiCache($24/월) 대신 EFS($3/월)로 데이터 유실 방지 |
+| **모니터링** | Prometheus + Grafana + CloudWatch Logs | 메트릭: Prometheus 직접 스크래핑, 로그: awslogs → CloudWatch |
+
+---
+
+## 전체 아키텍처 다이어그램
+
+```
+[보호대상자 앱]              [보호자 앱]
+      │ GPS 전송 (1분마다)         │ 위치 조회 / SSE 연결
+      │ HTTPS                      │ HTTPS
+      └────────────────────────────┘
+                     │
+      ┌──────────────▼──────────────────────────────────────────┐
+      │  EC2 t3.medium  (ECS EC2 Launch Type)                   │
+      │                                                         │
+      │  ┌──────────────────────────────────────────────────┐  │
+      │  │  ECS Service: nginx + certbot                     │  │
+      │  │  - 포트 80  → HTTPS 리다이렉트                    │  │
+      │  │  - 포트 443 → Let's Encrypt SSL (자동 갱신)       │  │
+      │  │  - upstream → spring-app:8080                     │  │
+      │  └───────────────────────┬──────────────────────────┘  │
+      │                          │                              │
+      │  ┌───────────────────────▼──────────────────────────┐  │
+      │  │  ECS Service: spring-app                          │  │
+      │  │                                                   │  │
+      │  │  GPS 수신 시 4가지 동작:                          │  │
+      │  │  ① DB INSERT   → GPS 이력 저장 (경로 조회용)     │  │
+      │  │  ② Redis SET   → gps:latest:{key}, TTL 5분       │  │
+      │  │  ③ SSE push    → 연결된 보호자에게 실시간 전송    │  │
+      │  │  ④ SQS send    → gps-llm-queue                   │  │
+      │  │                                                   │  │
+      │  │  LLM 이상감지 수신 시:                            │  │
+      │  │  ⑤ HTTP POST 수신 → Push 알림 발송               │  │
+      │  └───────┬──────────────────────┬───────────────────┘  │
+      │          │                      │                       │
+      │  ┌───────▼──────┐   ┌───────────▼──────────────────┐  │
+      │  │  ECS Service  │   │  RDS: PostgreSQL 16           │  │
+      │  │  redis        │   │  - GPS 이력                   │  │
+      │  │  (EFS + AOF)  │   │  - 회원 정보 전체             │  │
+      │  │               │   │  - db.t3.micro, gp3 20GB     │  │
+      │  │  refresh:{}   │   └──────────────────────────────┘  │
+      │  │  sms:{}       │                                      │
+      │  │  gps:latest:{}│                                      │
+      │  └───────────────┘                                      │
+      │                                                         │
+      │  ┌──────────────────────────────────────────────────┐  │
+      │  │  ECS Service: llm-container                       │  │
+      │  │  - SQS gps-llm-queue 폴링                        │  │
+      │  │  - 이상 경로 패턴 감지                            │  │
+      │  │  - 감지 시 → HTTP POST → spring-app              │  │
+      │  └──────────────────────────────────────────────────┘  │
+      │                                                         │
+      │  ┌──────────────────────────────────────────────────┐  │
+      │  │  ECS Service: monitoring                          │  │
+      │  │                                                   │  │
+      │  │  [Prometheus] ← /actuator/prometheus 스크래핑    │  │
+      │  │    메트릭 저장 (Docker named volume, 15일 보존)   │  │
+      │  │                                                   │  │
+      │  │  [Grafana :3000]                                  │  │
+      │  │    ├─ 데이터소스: Prometheus (메트릭)             │  │
+      │  │    └─ 데이터소스: CloudWatch Logs (로그)         │  │
+      │  └──────────────────────────────────────────────────┘  │
+      │                                                         │
+      │  spring-app → [awslogs 드라이버] → CloudWatch Logs     │
+      │                                    (/ecs/recaring)      │
+      └─────────────────────────────────────────────────────────┘
+                          │ SQS send
+                          ▼
+               ┌──────────────────────┐
+               │  AWS SQS:            │
+               │  gps-llm-queue       │  (LLM 분석용)
+               └──────────────────────┘
+                          │ 폴링
+                          ↑
+                 llm-container (EC2 내)
+```
+
+---
+
+## 데이터 흐름
+
+### 1. GPS 수신 흐름 (보호대상자 → 시스템)
+
+```
+보호대상자 앱
+  → (HTTPS) nginx
+  → spring-app
+       ├─ PostgreSQL INSERT  (lat, lng, timestamp, memberKey)
+       ├─ Redis SET          gps:latest:{memberKey} = {lat, lng, ts}  TTL 5분
+       ├─ SSE push           해당 보호대상자를 구독 중인 보호자 채널로 즉시 전송
+       └─ SQS send           gps-llm-queue → LLM 컨테이너
+```
+
+### 2. 보호자 위치 조회 흐름
+
+```
+보호자 앱 (지도 화면 — 실시간)
+  → spring-app SSE 연결 (/location/stream/{memberKey})
+  → GPS 수신마다 SSE push
+  → Redis gps:latest:{memberKey} 초기값 로드 (Cache Miss 시 DB fallback)
+
+보호자 앱 (경로 히스토리 조회 — 날짜별)
+  → spring-app REST API
+  → PostgreSQL 날짜 범위 쿼리 (Redis 불필요)
+```
+
+### 3. LLM 이상감지 흐름
+
+```
+SQS gps-llm-queue
+  → llm-container 폴링 (30초 간격)
+  → GPS 좌표 패턴 분석
+  → 이상 감지 시: HTTP POST → spring-app /internal/anomaly
+  → spring-app → FCM Push 알림 발송
+```
+
+### 4. 모니터링 흐름
+
+```
+메트릭:
+  Spring /actuator/prometheus
+    → Prometheus 직접 스크래핑 (15초 간격)
+    → Docker named volume 저장 (15일 보존)
+    → Grafana 시각화
+
+로그:
+  spring-app ECS Task → awslogs 드라이버
+    → CloudWatch Logs (/ecs/recaring 로그 그룹)
+    → Grafana CloudWatch 데이터소스로 조회
+```
+
+---
+
+## 컴포넌트별 ECS 설정
+
+| ECS Service | 이미지 | 메모리 한도 | 포트 | 볼륨 |
+|------------|--------|------------|------|------|
+| nginx | nginx:latest | 128MB | 80, 443 (호스트 바인딩) | EFS(certbot certs), nginx conf |
+| certbot | certbot/certbot | 64MB | — | EFS(certbot certs) |
+| spring-app | brianchoi506/re-caring:latest | 600MB | 8080 | — (로그: awslogs → CloudWatch) |
+| redis | redis:7-alpine | 128MB | 6379 | EFS(/data, AOF) |
+| llm-container | (별도 이미지) | 512MB+ | — | — |
+| prometheus | prom/prometheus | 256MB | 9090 | Docker named volume |
+| grafana | grafana/grafana:latest | 192MB | 3000 | Docker named volume |
+| **합계 (EC2)** | | **~1.9GB** | | |
+
+**PostgreSQL → RDS (EC2 외부, AWS 관리형)**
+
+| RDS | 엔진 | 스펙 | 스토리지 | 비고 |
+|-----|------|------|---------|------|
+| recaring-db | PostgreSQL 16 | db.t3.micro | gp3 20GB | 자동 백업 7일, 포인트인타임 복구 |
+
+> PostgreSQL을 ECS + EFS로 운영하면 NFS 위에 DB 데이터 디렉토리가 올라가 fsync 동작 차이와 파일 락 이슈로 데이터 손상 위험이 있음. 핵심 비즈니스 데이터(GPS 이력, 회원 정보)는 RDS로 분리.
+
+> **Spring JVM 메모리 제한 필수**: `JAVA_OPTS="-Xms256m -Xmx512m"`
+> t3.medium 4GB → OS + ECS Agent ~400MB 제외 시 가용 3.6GB, 여유 약 1.1GB
+
+---
+
+## Redis 데이터 구조
+
+```
+Redis (EFS AOF 활성화: --appendonly yes --appendfsync everysec)
+  ├── refresh:{memberKey}        RefreshToken          TTL: 7일
+  ├── sms:{phone}                SMS 인증코드          TTL: 3분
+  └── gps:latest:{memberKey}     GPS 최신 위치         TTL: 5분
+                                 { lat, lng, timestamp }
+```
+
+Task 재시작 시 EFS의 AOF 파일로 자동 복구. 다운타임 30~60초, 데이터 유실 없음.
+
+---
+
+## 장애 격리
+
+| 장애 대상 | 영향 범위 | 복구 방식 |
+|---------|---------|---------|
+| Spring 크래시 | Spring만 30~60초 불가 | ECS 자동 재시작 |
+| Redis 크래시 | 로그인/캐시 일시 불가 | ECS 자동 재시작 + EFS AOF 복구 |
+| RDS 크래시 | GPS 저장 일시 실패 | RDS 자동 복구 (Multi-AZ 미적용 시 수분 소요) |
+| LLM 크래시 | 이상감지 알림만 불가 | ECS 자동 재시작 |
+| Monitoring 크래시 | Grafana 화면만 불가 | ECS 자동 재시작 |
+| SQS 다운 | LLM 분석 불가 | AWS 관리형 Multi-AZ 자동 복구 |
+| EC2 크래시 | 전체 영향 | EC2 Auto Recovery (MVP 수준 감수) |
+
+---
+
+## 배포 파이프라인
+
+```
+GitHub Actions
+  → ECR push
+  → aws ecs update-service --force-new-deployment
+  → 신규 Task 기동 → Cloud Map에 등록 → 헬스체크 통과
+  → nginx가 Cloud Map DNS 재확인 (TTL 10s) → 트래픽 신규 Task로 전환
+  → 구 Task Cloud Map 해제 → 구 Task 종료 (무중단)
+```
+
+- nginx upstream: `resolver 169.254.169.253 valid=10s;` + Cloud Map DNS명(`spring-app.recaring.local`) 사용
+- spring-app ECS 서비스: `minimum_healthy_percent=100, maximum_percent=200` (신규 기동 후 구 종료)
+
+---
+
+## AWS 관리형 서비스
+
+| 서비스 | 용도 | 비고 |
+|--------|------|------|
+| SQS (gps-llm-queue) | LLM 비동기 파이프라인 | Standard Queue, 가시성 타임아웃 60초 |
+| SSM Parameter Store | DB/JWT/API 시크릿 관리 | Standard (무료) |
+| EFS | Redis AOF + certbot certs | ~$1/월 (Spring 로그는 CloudWatch awslogs) |
+| CloudWatch Logs | Spring 애플리케이션 로그 (awslogs) | /ecs/recaring 로그 그룹, 무료 티어 5GB/월 |
+| ECR | 컨테이너 이미지 저장 | ~$0.5/월 |
+
+---
+
+## 월 비용
+
+| 항목 | 월 비용 |
+|------|--------|
+| EC2 t3.medium | $30 |
+| RDS db.t3.micro + gp3 20GB | $15 |
+| EFS (Redis AOF + certs) | ~$1 |
+| SQS | ~$0.5 |
+| ECR | ~$0.5 |
+| CloudWatch Logs | ~$0 (MVP 무료 티어) |
+| **합계** | **~$47/월** |
+
+---
+
+## 향후 스케일업 전환 포인트
+
+| 시점 | 조치 |
+|------|------|
+| 사용자 수백 명 이상 | EC2 t3.large 업그레이드 또는 Fargate 전환 |
+| PostgreSQL 부하 증가 | RDS Multi-AZ 활성화 |
+| Redis 가용성 강화 필요 | ElastiCache t4g.micro + Replica 1개 |
+| 보호자 동시 접속 증가 | Spring 다중 Task + Redis Pub/Sub SSE 동기화 추가 |
+| LLM 처리량 증가 | LLM 전용 EC2 분리 또는 SQS Consumer 수평 확장 |
+| FCM 푸시 필요 시 (복수 이벤트 트리거) | SNS 재도입 + SQS 구독 구조로 전환 |

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: recaring
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/monitoring/grafana/provisioning/datasources/local.yml
+++ b/monitoring/grafana/provisioning/datasources/local.yml
@@ -3,12 +3,14 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: prometheus
     url: http://prometheus:9090
     isDefault: true
     editable: false
 
   - name: CloudWatch
     type: cloudwatch
+    uid: cloudwatch
     jsonData:
       authType: default
       defaultRegion: ap-northeast-2

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -45,7 +45,7 @@ coolsms:
   sender: ${COOLSMS_SENDER}
 
 client:
-  url: re-caring.duckdns.org
+  url: re-caring.com
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -41,6 +41,25 @@ coolsms:
 client:
   url: http://localhost:3000
 
+aws:
+  sqs:
+    gps-queue-url: ""
+
+gps:
+  pattern:
+    analysis:
+      interval-ms: 1800000
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+
 springdoc:
   swagger-ui:
     url: /v3/api-docs

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -45,7 +45,19 @@ coolsms:
   sender: ${COOLSMS_SENDER}
 
 client:
-  url: re-caring.duckdns.org
+  url: re-caring.com
+
+aws:
+  access-key: ${AWS_ACCESS_KEY}
+  secret-key: ${AWS_SECRET_KEY}
+  region: ${AWS_REGION:ap-northeast-2}
+  sqs:
+    gps-queue-url: ${AWS_SQS_GPS_QUEUE_URL}
+
+gps:
+  pattern:
+    analysis:
+      interval-ms: ${GPS_PATTERN_INTERVAL_MS:1800000}
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## Summary

Claude 설정 파일 언어 규칙 적용 및 yml 설정 업데이트.

## 변경 파일 목록

### Claude 설정
- `CLAUDE.md` — 프로젝트 분석 지침 및 빌드 명령어 업데이트
- `.claude/agents/deploy.md` — 배포 에이전트 추가
- `.claude/skills/deploy/SKILL.md` — 배포 스킬 업데이트
- `.claude/skills/feature-dev/SKILL.md` — 기능 개발 스킬 업데이트
- `.claude/skills/feature-dev/references/architecture.md` — 아키텍처 참조 문서 업데이트
- `.claude/skills/feature-dev/references/patterns.md` — 패턴 참조 문서 업데이트
- `.claude/skills/feature-dev/references/snapshot.md` — API·엔티티 현황 스냅샷 추가
- `.claude/skills/test-write/SKILL.md` — 테스트 작성 스킬 추가

### 애플리케이션 설정
- `src/main/resources/application-dev.yml` — dev 프로파일 설정 업데이트
- `src/main/resources/application-local.yml` — local 프로파일 설정 업데이트
- `src/main/resources/application-prod.yml` — prod 프로파일 설정 업데이트

### 모니터링
- `monitoring/grafana/provisioning/datasources/local.yml` — Grafana 데이터소스 설정 업데이트
- `monitoring/grafana/provisioning/dashboards/dashboard.yml` — Grafana 대시보드 프로비저닝 설정 추가

### 문서
- `docs/architecture.md` — 시스템 아키텍처 문서 추가

## 참고

- `src/main/java/**`, `src/test/java/**`, `terraform/**`, `nginx/**` 등 코드 변경은 별도 PR로 분리 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 배포 자동화 파이프라인 추가 (빌드, 테스트, PR 생성, CI 대기, 머지, 배포까지 자동화)
  * GPS 패턴 분석 설정 추가
  * Grafana 및 Prometheus 기반 모니터링 인프라 구성

* **설정**
  * 개발/운영 환경 도메인 URL 업데이트 (re-caring.com)
  * AWS SQS 큐 설정 추가
  * 액추에이터 및 메트릭 수집 활성화

* **문서**
  * 시스템 아키텍처 및 개발 가이드라인 문서화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->