### PR TITLE
fix: move Redis config to correct spring.data.redis path in prod profile

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,6 +16,11 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
 management:
   endpoints:
     web:
@@ -25,10 +30,6 @@ management:
     distribution:
       percentiles-histogram:
         http.server.requests: true
-
-redis:
-  host: ${REDIS_HOST}
-  port: ${REDIS_PORT}
 
 jwt:
   secret-key: ${JWT_KEY}


### PR DESCRIPTION
## 변경 이유

기존 `application-prod.yml`에서 Redis 설정이 최상위 `redis.host`/`redis.port` 경로에 위치해 있었다.

Spring Boot의 Redis auto-configuration(`RedisAutoConfiguration`)은 `spring.data.redis.*` 하위 프로퍼티만 읽기 때문에, 기존 설정은 완전히 무시되어 **localhost:6379 기본값**으로 연결을 시도하고 있었다.

## 변경 내용

```yaml
# Before (잘못된 경로 — Spring Boot가 읽지 않음)
redis:
  host: ${REDIS_HOST}
  port: ${REDIS_PORT}

# After (올바른 경로)
spring:
  data:
    redis:
      host: ${REDIS_HOST}
      port: ${REDIS_PORT}
```

## 영향

- prod 프로파일에서 `REDIS_HOST` / `REDIS_PORT` 환경 변수가 정상적으로 Redis 연결에 반영됨
- 다른 파일 변경 없음 (단일 파일, 단일 커밋)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Redis 설정을 표준화된 구조로 업데이트했습니다. 환경 변수를 통한 연결 설정이 개선되었으며, 프로덕션 환경에서 Redis 연결이 더 안정적으로 관리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->