### PR TITLE
fix: revert workflow environment from prod back to dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.merged == true
-    environment: prod
+    environment: dev
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- GitHub Actions deploy workflow의 `environment` 값을 `prod`에서 `dev`로 되돌림

## Changes
- `.github/workflows/deploy.yml`: `environment: prod` → `environment: dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기타 작업 (Chores)**
  * 배포 환경 구성이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->