### PR TITLE
feat: add ST-001 more menu API

### DIFF
--- a/src/main/java/com/recaring/care/implement/CareRelationshipReader.java
+++ b/src/main/java/com/recaring/care/implement/CareRelationshipReader.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
@@ -60,7 +61,7 @@ public class CareRelationshipReader {
     public CareRole findCareRole(String wardKey, String caregiverKey) {
         return careRelationshipRepository.findAllByWardMemberKey(wardKey)
                 .stream()
-                .filter(relationship -> caregiverKey.equals(relationship.getCaregiverMemberKey()))
+                .filter(relationship -> Objects.equals(caregiverKey, relationship.getCaregiverMemberKey()))
                 .map(CareRelationship::getCareRole)
                 .findFirst()
                 .orElseThrow(() -> new AppException(ErrorType.NOT_CARE_RELATED_WARD));

--- a/src/main/java/com/recaring/care/implement/CareRelationshipReader.java
+++ b/src/main/java/com/recaring/care/implement/CareRelationshipReader.java
@@ -7,6 +7,8 @@ import com.recaring.care.dataaccess.entity.CareRole;
 import com.recaring.care.dataaccess.repository.CareRelationshipRepository;
 import com.recaring.member.dataaccess.entity.Member;
 import com.recaring.member.implement.MemberReader;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -53,5 +55,14 @@ public class CareRelationshipReader {
                     return new CaregiverInfo(caregiver.getMemberKey(), caregiver.getName(), caregiver.getPhone(), r.getCareRole());
                 })
                 .toList();
+    }
+
+    public CareRole findCareRole(String wardKey, String caregiverKey) {
+        return careRelationshipRepository.findAllByWardMemberKey(wardKey)
+                .stream()
+                .filter(relationship -> caregiverKey.equals(relationship.getCaregiverMemberKey()))
+                .map(CareRelationship::getCareRole)
+                .findFirst()
+                .orElseThrow(() -> new AppException(ErrorType.NOT_CARE_RELATED_WARD));
     }
 }

--- a/src/main/java/com/recaring/moremenu/business/MoreMenuContextType.java
+++ b/src/main/java/com/recaring/moremenu/business/MoreMenuContextType.java
@@ -1,0 +1,8 @@
+package com.recaring.moremenu.business;
+
+public enum MoreMenuContextType {
+    WARD,
+    MANAGER,
+    GUARDIAN
+}
+

--- a/src/main/java/com/recaring/moremenu/business/MoreMenuInfo.java
+++ b/src/main/java/com/recaring/moremenu/business/MoreMenuInfo.java
@@ -1,0 +1,13 @@
+package com.recaring.moremenu.business;
+
+import java.util.List;
+
+public record MoreMenuInfo(
+        MoreMenuContextType contextType,
+        List<MoreMenuSectionInfo> sections
+) {
+    public MoreMenuInfo {
+        sections = List.copyOf(sections);
+    }
+}
+

--- a/src/main/java/com/recaring/moremenu/business/MoreMenuItemInfo.java
+++ b/src/main/java/com/recaring/moremenu/business/MoreMenuItemInfo.java
@@ -1,0 +1,10 @@
+package com.recaring.moremenu.business;
+
+public record MoreMenuItemInfo(
+        MoreMenuItemKey itemKey,
+        boolean enabled,
+        MoreMenuTargetType targetType,
+        String target
+) {
+}
+

--- a/src/main/java/com/recaring/moremenu/business/MoreMenuItemKey.java
+++ b/src/main/java/com/recaring/moremenu/business/MoreMenuItemKey.java
@@ -1,0 +1,17 @@
+package com.recaring.moremenu.business;
+
+public enum MoreMenuItemKey {
+    LOCATION_COLLECTION_SETTING,
+    NOTIFICATION_SETTING,
+    SAFE_ZONE_SETTING,
+    WARD_SETTING,
+    CAREGIVER_SETTING,
+    PROTECTOR_SETTING,
+    FAQ,
+    TERMS,
+    INQUIRY,
+    APP_VERSION,
+    SIGN_OUT,
+    WITHDRAW_ACCOUNT
+}
+

--- a/src/main/java/com/recaring/moremenu/business/MoreMenuSectionInfo.java
+++ b/src/main/java/com/recaring/moremenu/business/MoreMenuSectionInfo.java
@@ -1,0 +1,13 @@
+package com.recaring.moremenu.business;
+
+import java.util.List;
+
+public record MoreMenuSectionInfo(
+        MoreMenuSectionKey sectionKey,
+        List<MoreMenuItemInfo> items
+) {
+    public MoreMenuSectionInfo {
+        items = List.copyOf(items);
+    }
+}
+

--- a/src/main/java/com/recaring/moremenu/business/MoreMenuSectionKey.java
+++ b/src/main/java/com/recaring/moremenu/business/MoreMenuSectionKey.java
@@ -1,0 +1,7 @@
+package com.recaring.moremenu.business;
+
+public enum MoreMenuSectionKey {
+    SETTING,
+    MORE
+}
+

--- a/src/main/java/com/recaring/moremenu/business/MoreMenuService.java
+++ b/src/main/java/com/recaring/moremenu/business/MoreMenuService.java
@@ -21,11 +21,11 @@ public class MoreMenuService {
 
     public MoreMenuInfo getMenu(String memberKey, String wardKey) {
         Member member = memberReader.findByMemberKey(memberKey);
-        MoreMenuContextType contextType = resolveContextType(member, memberKey, wardKey);
+        MoreMenuContextType contextType = resolveContextType(member, wardKey);
         return moreMenuFactory.getMenu(contextType);
     }
 
-    private MoreMenuContextType resolveContextType(Member member, String memberKey, String wardKey) {
+    private MoreMenuContextType resolveContextType(Member member, String wardKey) {
         if (member.getRole() == MemberRole.WARD) {
             return MoreMenuContextType.WARD;
         }
@@ -33,7 +33,7 @@ public class MoreMenuService {
             throw new AppException(ErrorType.WARD_KEY_REQUIRED);
         }
 
-        CareRole careRole = careRelationshipReader.findCareRole(wardKey, memberKey);
+        CareRole careRole = careRelationshipReader.findCareRole(wardKey, member.getMemberKey());
         return switch (careRole) {
             case MANAGER -> MoreMenuContextType.MANAGER;
             case GUARDIAN -> MoreMenuContextType.GUARDIAN;

--- a/src/main/java/com/recaring/moremenu/business/MoreMenuService.java
+++ b/src/main/java/com/recaring/moremenu/business/MoreMenuService.java
@@ -1,0 +1,42 @@
+package com.recaring.moremenu.business;
+
+import com.recaring.care.dataaccess.entity.CareRole;
+import com.recaring.care.implement.CareRelationshipReader;
+import com.recaring.member.dataaccess.entity.Member;
+import com.recaring.member.dataaccess.entity.MemberRole;
+import com.recaring.member.implement.MemberReader;
+import com.recaring.moremenu.implement.MoreMenuFactory;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MoreMenuService {
+
+    private final MemberReader memberReader;
+    private final CareRelationshipReader careRelationshipReader;
+    private final MoreMenuFactory moreMenuFactory;
+
+    public MoreMenuInfo getMenu(String memberKey, String wardKey) {
+        Member member = memberReader.findByMemberKey(memberKey);
+        MoreMenuContextType contextType = resolveContextType(member, memberKey, wardKey);
+        return moreMenuFactory.getMenu(contextType);
+    }
+
+    private MoreMenuContextType resolveContextType(Member member, String memberKey, String wardKey) {
+        if (member.getRole() == MemberRole.WARD) {
+            return MoreMenuContextType.WARD;
+        }
+        if (wardKey == null || wardKey.isBlank()) {
+            throw new AppException(ErrorType.WARD_KEY_REQUIRED);
+        }
+
+        CareRole careRole = careRelationshipReader.findCareRole(wardKey, memberKey);
+        return switch (careRole) {
+            case MANAGER -> MoreMenuContextType.MANAGER;
+            case GUARDIAN -> MoreMenuContextType.GUARDIAN;
+        };
+    }
+}

--- a/src/main/java/com/recaring/moremenu/business/MoreMenuTargetType.java
+++ b/src/main/java/com/recaring/moremenu/business/MoreMenuTargetType.java
@@ -1,0 +1,10 @@
+package com.recaring.moremenu.business;
+
+public enum MoreMenuTargetType {
+    SCREEN,
+    WEBVIEW,
+    EXTERNAL_LINK,
+    ACTION,
+    CLIENT_ACTION
+}
+

--- a/src/main/java/com/recaring/moremenu/controller/MoreMenuController.java
+++ b/src/main/java/com/recaring/moremenu/controller/MoreMenuController.java
@@ -1,0 +1,40 @@
+package com.recaring.moremenu.controller;
+
+import com.recaring.moremenu.business.MoreMenuService;
+import com.recaring.moremenu.controller.response.MoreMenuResponse;
+import com.recaring.security.vo.AuthMember;
+import com.recaring.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/more")
+@RequiredArgsConstructor
+@Tag(name = "More", description = "More menu API")
+public class MoreMenuController {
+
+    private final MoreMenuService moreMenuService;
+
+    @Operation(
+            summary = "Get more menu",
+            description = "Returns the ST-001 more menu for the authenticated member. Guardian accounts must pass wardKey."
+    )
+    @GetMapping("/menu")
+    public ResponseEntity<ApiResponse<MoreMenuResponse>> getMenu(
+            @Parameter(hidden = true)
+            @AuthMember String memberKey,
+            @Parameter(description = "Ward member key. Required for guardian and manager contexts.", required = false)
+            @RequestParam(required = false) String wardKey
+    ) {
+        MoreMenuResponse response = MoreMenuResponse.from(moreMenuService.getMenu(memberKey, wardKey));
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}
+

--- a/src/main/java/com/recaring/moremenu/controller/response/MoreMenuItemResponse.java
+++ b/src/main/java/com/recaring/moremenu/controller/response/MoreMenuItemResponse.java
@@ -1,0 +1,22 @@
+package com.recaring.moremenu.controller.response;
+
+import com.recaring.moremenu.business.MoreMenuItemInfo;
+import com.recaring.moremenu.business.MoreMenuItemKey;
+import com.recaring.moremenu.business.MoreMenuTargetType;
+
+public record MoreMenuItemResponse(
+        MoreMenuItemKey itemKey,
+        boolean enabled,
+        MoreMenuTargetType targetType,
+        String target
+) {
+    public static MoreMenuItemResponse from(MoreMenuItemInfo info) {
+        return new MoreMenuItemResponse(
+                info.itemKey(),
+                info.enabled(),
+                info.targetType(),
+                info.target()
+        );
+    }
+}
+

--- a/src/main/java/com/recaring/moremenu/controller/response/MoreMenuResponse.java
+++ b/src/main/java/com/recaring/moremenu/controller/response/MoreMenuResponse.java
@@ -1,0 +1,22 @@
+package com.recaring.moremenu.controller.response;
+
+import com.recaring.moremenu.business.MoreMenuContextType;
+import com.recaring.moremenu.business.MoreMenuInfo;
+
+import java.util.List;
+
+public record MoreMenuResponse(
+        MoreMenuContextType contextType,
+        List<MoreMenuSectionResponse> sections
+) {
+    public static MoreMenuResponse from(MoreMenuInfo info) {
+        return new MoreMenuResponse(
+                info.contextType(),
+                info.sections()
+                        .stream()
+                        .map(MoreMenuSectionResponse::from)
+                        .toList()
+        );
+    }
+}
+

--- a/src/main/java/com/recaring/moremenu/controller/response/MoreMenuSectionResponse.java
+++ b/src/main/java/com/recaring/moremenu/controller/response/MoreMenuSectionResponse.java
@@ -1,0 +1,22 @@
+package com.recaring.moremenu.controller.response;
+
+import com.recaring.moremenu.business.MoreMenuSectionInfo;
+import com.recaring.moremenu.business.MoreMenuSectionKey;
+
+import java.util.List;
+
+public record MoreMenuSectionResponse(
+        MoreMenuSectionKey sectionKey,
+        List<MoreMenuItemResponse> items
+) {
+    public static MoreMenuSectionResponse from(MoreMenuSectionInfo info) {
+        return new MoreMenuSectionResponse(
+                info.sectionKey(),
+                info.items()
+                        .stream()
+                        .map(MoreMenuItemResponse::from)
+                        .toList()
+        );
+    }
+}
+

--- a/src/main/java/com/recaring/moremenu/implement/MoreMenuFactory.java
+++ b/src/main/java/com/recaring/moremenu/implement/MoreMenuFactory.java
@@ -1,0 +1,105 @@
+package com.recaring.moremenu.implement;
+
+import com.recaring.moremenu.business.MoreMenuContextType;
+import com.recaring.moremenu.business.MoreMenuInfo;
+import com.recaring.moremenu.business.MoreMenuItemInfo;
+import com.recaring.moremenu.business.MoreMenuItemKey;
+import com.recaring.moremenu.business.MoreMenuSectionInfo;
+import com.recaring.moremenu.business.MoreMenuSectionKey;
+import com.recaring.moremenu.business.MoreMenuTargetType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class MoreMenuFactory {
+
+    private static final String LOCATION_COLLECTION_SETTING_TARGET = "ST-002";
+    private static final String NOTIFICATION_SETTING_TARGET = "ST-003";
+    private static final String SAFE_ZONE_SETTING_TARGET = "ZN-001";
+    private static final String WARD_SETTING_TARGET = "ST-004";
+    private static final String CAREGIVER_SETTING_TARGET = "ST-005";
+    private static final String PROTECTOR_SETTING_TARGET = "ST-005";
+    private static final String FAQ_TARGET = "CS-001";
+    private static final String TERMS_TARGET = "TERMS";
+    private static final String INQUIRY_TARGET = "APP_INQUIRY";
+    private static final String APP_VERSION_TARGET = "SHOW_APP_VERSION";
+    private static final String SIGN_OUT_TARGET = "/api/v1/auth/sign-out";
+    private static final String WITHDRAW_ACCOUNT_TARGET = "WITHDRAW_ACCOUNT";
+
+    public MoreMenuInfo getMenu(MoreMenuContextType contextType) {
+        return new MoreMenuInfo(
+                contextType,
+                List.of(
+                        settingSection(contextType),
+                        moreSection()
+                )
+        );
+    }
+
+    private MoreMenuSectionInfo settingSection(MoreMenuContextType contextType) {
+        return switch (contextType) {
+            case WARD -> new MoreMenuSectionInfo(
+                    MoreMenuSectionKey.SETTING,
+                    List.of(
+                            screen(MoreMenuItemKey.NOTIFICATION_SETTING, true, NOTIFICATION_SETTING_TARGET),
+                            screen(MoreMenuItemKey.PROTECTOR_SETTING, true, PROTECTOR_SETTING_TARGET)
+                    )
+            );
+            case MANAGER -> caregiverSettingSection(false);
+            case GUARDIAN -> caregiverSettingSection(true);
+        };
+    }
+
+    private MoreMenuSectionInfo caregiverSettingSection(boolean locationSettingsEnabled) {
+        return new MoreMenuSectionInfo(
+                MoreMenuSectionKey.SETTING,
+                List.of(
+                        screen(MoreMenuItemKey.LOCATION_COLLECTION_SETTING, locationSettingsEnabled, LOCATION_COLLECTION_SETTING_TARGET),
+                        screen(MoreMenuItemKey.NOTIFICATION_SETTING, true, NOTIFICATION_SETTING_TARGET),
+                        screen(MoreMenuItemKey.SAFE_ZONE_SETTING, locationSettingsEnabled, SAFE_ZONE_SETTING_TARGET),
+                        screen(MoreMenuItemKey.WARD_SETTING, true, WARD_SETTING_TARGET),
+                        screen(MoreMenuItemKey.CAREGIVER_SETTING, true, CAREGIVER_SETTING_TARGET)
+                )
+        );
+    }
+
+    private MoreMenuSectionInfo moreSection() {
+        return new MoreMenuSectionInfo(
+                MoreMenuSectionKey.MORE,
+                List.of(
+                        webview(MoreMenuItemKey.FAQ, FAQ_TARGET),
+                        webview(MoreMenuItemKey.TERMS, TERMS_TARGET),
+                        externalLink(MoreMenuItemKey.INQUIRY, INQUIRY_TARGET),
+                        clientAction(MoreMenuItemKey.APP_VERSION, APP_VERSION_TARGET),
+                        action(MoreMenuItemKey.SIGN_OUT, SIGN_OUT_TARGET),
+                        screen(MoreMenuItemKey.WITHDRAW_ACCOUNT, true, WITHDRAW_ACCOUNT_TARGET)
+                )
+        );
+    }
+
+    private MoreMenuItemInfo screen(MoreMenuItemKey itemKey, boolean enabled, String target) {
+        return item(itemKey, enabled, MoreMenuTargetType.SCREEN, target);
+    }
+
+    private MoreMenuItemInfo webview(MoreMenuItemKey itemKey, String target) {
+        return item(itemKey, true, MoreMenuTargetType.WEBVIEW, target);
+    }
+
+    private MoreMenuItemInfo externalLink(MoreMenuItemKey itemKey, String target) {
+        return item(itemKey, true, MoreMenuTargetType.EXTERNAL_LINK, target);
+    }
+
+    private MoreMenuItemInfo clientAction(MoreMenuItemKey itemKey, String target) {
+        return item(itemKey, true, MoreMenuTargetType.CLIENT_ACTION, target);
+    }
+
+    private MoreMenuItemInfo action(MoreMenuItemKey itemKey, String target) {
+        return item(itemKey, true, MoreMenuTargetType.ACTION, target);
+    }
+
+    private MoreMenuItemInfo item(MoreMenuItemKey itemKey, boolean enabled, MoreMenuTargetType targetType, String target) {
+        return new MoreMenuItemInfo(itemKey, enabled, targetType, target);
+    }
+}
+

--- a/src/main/java/com/recaring/moremenu/implement/MoreMenuFactory.java
+++ b/src/main/java/com/recaring/moremenu/implement/MoreMenuFactory.java
@@ -18,8 +18,7 @@ public class MoreMenuFactory {
     private static final String NOTIFICATION_SETTING_TARGET = "ST-003";
     private static final String SAFE_ZONE_SETTING_TARGET = "ZN-001";
     private static final String WARD_SETTING_TARGET = "ST-004";
-    private static final String CAREGIVER_SETTING_TARGET = "ST-005";
-    private static final String PROTECTOR_SETTING_TARGET = "ST-005";
+    private static final String CARE_RELATIONSHIP_SETTING_TARGET = "ST-005";
     private static final String FAQ_TARGET = "CS-001";
     private static final String TERMS_TARGET = "TERMS";
     private static final String INQUIRY_TARGET = "APP_INQUIRY";
@@ -43,7 +42,7 @@ public class MoreMenuFactory {
                     MoreMenuSectionKey.SETTING,
                     List.of(
                             screen(MoreMenuItemKey.NOTIFICATION_SETTING, true, NOTIFICATION_SETTING_TARGET),
-                            screen(MoreMenuItemKey.PROTECTOR_SETTING, true, PROTECTOR_SETTING_TARGET)
+                            screen(MoreMenuItemKey.PROTECTOR_SETTING, true, CARE_RELATIONSHIP_SETTING_TARGET)
                     )
             );
             case MANAGER -> caregiverSettingSection(false);
@@ -59,7 +58,7 @@ public class MoreMenuFactory {
                         screen(MoreMenuItemKey.NOTIFICATION_SETTING, true, NOTIFICATION_SETTING_TARGET),
                         screen(MoreMenuItemKey.SAFE_ZONE_SETTING, locationSettingsEnabled, SAFE_ZONE_SETTING_TARGET),
                         screen(MoreMenuItemKey.WARD_SETTING, true, WARD_SETTING_TARGET),
-                        screen(MoreMenuItemKey.CAREGIVER_SETTING, true, CAREGIVER_SETTING_TARGET)
+                        screen(MoreMenuItemKey.CAREGIVER_SETTING, true, CARE_RELATIONSHIP_SETTING_TARGET)
                 )
         );
     }

--- a/src/test/java/com/recaring/care/implement/CareRelationshipReaderTest.java
+++ b/src/test/java/com/recaring/care/implement/CareRelationshipReaderTest.java
@@ -1,0 +1,70 @@
+package com.recaring.care.implement;
+
+import com.recaring.care.dataaccess.entity.CareRole;
+import com.recaring.care.dataaccess.repository.CareRelationshipRepository;
+import com.recaring.care.fixture.CareFixture;
+import com.recaring.member.implement.MemberReader;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("케어 관계 Reader 단위 테스트")
+class CareRelationshipReaderTest {
+
+    @InjectMocks
+    private CareRelationshipReader careRelationshipReader;
+
+    @Mock
+    private CareRelationshipRepository careRelationshipRepository;
+
+    @Mock
+    private MemberReader memberReader;
+
+    @Test
+    @DisplayName("대상자에 대한 케어 관계 역할을 조회한다")
+    void findCareRole_returns_role() {
+        given(careRelationshipRepository.findAllByWardMemberKey(CareFixture.WARD_MEMBER_KEY))
+                .willReturn(List.of(
+                        CareFixture.createGuardianRelationship(CareFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY),
+                        CareFixture.createManagerRelationship(CareFixture.WARD_MEMBER_KEY, CareFixture.MANAGER_MEMBER_KEY)
+                ));
+
+        CareRole result = careRelationshipReader.findCareRole(
+                CareFixture.WARD_MEMBER_KEY,
+                CareFixture.MANAGER_MEMBER_KEY
+        );
+
+        assertThat(result).isEqualTo(CareRole.MANAGER);
+        then(careRelationshipRepository).should(times(1)).findAllByWardMemberKey(CareFixture.WARD_MEMBER_KEY);
+    }
+
+    @Test
+    @DisplayName("대상자와 관계가 없으면 예외가 발생한다")
+    void findCareRole_throws_exception_when_not_related() {
+        given(careRelationshipRepository.findAllByWardMemberKey(CareFixture.WARD_MEMBER_KEY))
+                .willReturn(List.of(
+                        CareFixture.createGuardianRelationship(CareFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)
+                ));
+
+        assertThatThrownBy(() -> careRelationshipReader.findCareRole(
+                CareFixture.WARD_MEMBER_KEY,
+                CareFixture.MANAGER_MEMBER_KEY
+        ))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_CARE_RELATED_WARD);
+    }
+}

--- a/src/test/java/com/recaring/config/swagger/SwaggerConfigTest.java
+++ b/src/test/java/com/recaring/config/swagger/SwaggerConfigTest.java
@@ -3,9 +3,12 @@ package com.recaring.config.swagger;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("Swagger 설정 단위 테스트")
 class SwaggerConfigTest {
 

--- a/src/test/java/com/recaring/config/swagger/SwaggerConfigTest.java
+++ b/src/test/java/com/recaring/config/swagger/SwaggerConfigTest.java
@@ -1,0 +1,28 @@
+package com.recaring.config.swagger;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Swagger 설정 단위 테스트")
+class SwaggerConfigTest {
+
+    private final SwaggerConfig swaggerConfig = new SwaggerConfig();
+
+    @Test
+    @DisplayName("BearerAuth 보안 스키마를 제공한다")
+    void openAPI_has_bearer_auth_security_scheme() {
+        OpenAPI openAPI = swaggerConfig.openAPI();
+
+        assertThat(openAPI.getSecurity()).anySatisfy(requirement ->
+                assertThat(requirement).containsKey("BearerAuth"));
+        assertThat(openAPI.getComponents().getSecuritySchemes())
+                .containsKey("BearerAuth");
+        assertThat(openAPI.getComponents().getSecuritySchemes().get("BearerAuth").getScheme())
+                .isEqualTo("bearer");
+        assertThat(openAPI.getComponents().getSecuritySchemes().get("BearerAuth").getBearerFormat())
+                .isEqualTo("JWT");
+    }
+}

--- a/src/test/java/com/recaring/moremenu/business/MoreMenuServiceTest.java
+++ b/src/test/java/com/recaring/moremenu/business/MoreMenuServiceTest.java
@@ -1,0 +1,120 @@
+package com.recaring.moremenu.business;
+
+import com.recaring.care.dataaccess.entity.CareRole;
+import com.recaring.care.fixture.CareFixture;
+import com.recaring.care.implement.CareRelationshipReader;
+import com.recaring.member.implement.MemberReader;
+import com.recaring.moremenu.implement.MoreMenuFactory;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("더보기 메뉴 서비스 단위 테스트")
+class MoreMenuServiceTest {
+
+    @InjectMocks
+    private MoreMenuService moreMenuService;
+
+    @Mock
+    private MemberReader memberReader;
+
+    @Mock
+    private CareRelationshipReader careRelationshipReader;
+
+    @Mock
+    private MoreMenuFactory moreMenuFactory;
+
+    @Test
+    @DisplayName("보호 대상자는 wardKey 없이 보호 대상자 메뉴를 조회한다")
+    void getMenu_returns_ward_menu() {
+        MoreMenuInfo expected = menu(MoreMenuContextType.WARD);
+
+        given(memberReader.findByMemberKey(CareFixture.WARD_MEMBER_KEY))
+                .willReturn(CareFixture.createWardMember());
+        given(moreMenuFactory.getMenu(MoreMenuContextType.WARD)).willReturn(expected);
+
+        MoreMenuInfo result = moreMenuService.getMenu(CareFixture.WARD_MEMBER_KEY, null);
+
+        assertThat(result).isEqualTo(expected);
+        then(careRelationshipReader).shouldHaveNoInteractions();
+        then(moreMenuFactory).should(times(1)).getMenu(MoreMenuContextType.WARD);
+    }
+
+    @Test
+    @DisplayName("관리자는 wardKey로 관리자 메뉴를 조회한다")
+    void getMenu_returns_manager_menu() {
+        MoreMenuInfo expected = menu(MoreMenuContextType.MANAGER);
+
+        given(memberReader.findByMemberKey(CareFixture.MANAGER_MEMBER_KEY))
+                .willReturn(CareFixture.createGuardianMember(CareFixture.MANAGER_PHONE));
+        given(careRelationshipReader.findCareRole(CareFixture.WARD_MEMBER_KEY, CareFixture.MANAGER_MEMBER_KEY))
+                .willReturn(CareRole.MANAGER);
+        given(moreMenuFactory.getMenu(MoreMenuContextType.MANAGER)).willReturn(expected);
+
+        MoreMenuInfo result = moreMenuService.getMenu(CareFixture.MANAGER_MEMBER_KEY, CareFixture.WARD_MEMBER_KEY);
+
+        assertThat(result).isEqualTo(expected);
+        then(moreMenuFactory).should(times(1)).getMenu(MoreMenuContextType.MANAGER);
+    }
+
+    @Test
+    @DisplayName("주보호자는 wardKey로 주보호자 메뉴를 조회한다")
+    void getMenu_returns_guardian_menu() {
+        MoreMenuInfo expected = menu(MoreMenuContextType.GUARDIAN);
+
+        given(memberReader.findByMemberKey(CareFixture.GUARDIAN_MEMBER_KEY))
+                .willReturn(CareFixture.createGuardianMember());
+        given(careRelationshipReader.findCareRole(CareFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY))
+                .willReturn(CareRole.GUARDIAN);
+        given(moreMenuFactory.getMenu(MoreMenuContextType.GUARDIAN)).willReturn(expected);
+
+        MoreMenuInfo result = moreMenuService.getMenu(CareFixture.GUARDIAN_MEMBER_KEY, CareFixture.WARD_MEMBER_KEY);
+
+        assertThat(result).isEqualTo(expected);
+        then(moreMenuFactory).should(times(1)).getMenu(MoreMenuContextType.GUARDIAN);
+    }
+
+    @Test
+    @DisplayName("보호자는 wardKey가 없으면 예외가 발생한다")
+    void getMenu_throws_exception_when_ward_key_is_missing() {
+        given(memberReader.findByMemberKey(CareFixture.GUARDIAN_MEMBER_KEY))
+                .willReturn(CareFixture.createGuardianMember());
+
+        assertThatThrownBy(() -> moreMenuService.getMenu(CareFixture.GUARDIAN_MEMBER_KEY, null))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.WARD_KEY_REQUIRED);
+
+        then(careRelationshipReader).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("보호자는 wardKey가 공백이면 예외가 발생한다")
+    void getMenu_throws_exception_when_ward_key_is_blank() {
+        given(memberReader.findByMemberKey(CareFixture.GUARDIAN_MEMBER_KEY))
+                .willReturn(CareFixture.createGuardianMember());
+
+        assertThatThrownBy(() -> moreMenuService.getMenu(CareFixture.GUARDIAN_MEMBER_KEY, " "))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.WARD_KEY_REQUIRED);
+
+        then(careRelationshipReader).shouldHaveNoInteractions();
+    }
+
+    private MoreMenuInfo menu(MoreMenuContextType contextType) {
+        return new MoreMenuInfo(contextType, List.of());
+    }
+}

--- a/src/test/java/com/recaring/moremenu/business/MoreMenuServiceTest.java
+++ b/src/test/java/com/recaring/moremenu/business/MoreMenuServiceTest.java
@@ -58,10 +58,11 @@ class MoreMenuServiceTest {
     @DisplayName("관리자는 wardKey로 관리자 메뉴를 조회한다")
     void getMenu_returns_manager_menu() {
         MoreMenuInfo expected = menu(MoreMenuContextType.MANAGER);
+        var manager = CareFixture.createGuardianMember(CareFixture.MANAGER_PHONE);
 
         given(memberReader.findByMemberKey(CareFixture.MANAGER_MEMBER_KEY))
-                .willReturn(CareFixture.createGuardianMember(CareFixture.MANAGER_PHONE));
-        given(careRelationshipReader.findCareRole(CareFixture.WARD_MEMBER_KEY, CareFixture.MANAGER_MEMBER_KEY))
+                .willReturn(manager);
+        given(careRelationshipReader.findCareRole(CareFixture.WARD_MEMBER_KEY, manager.getMemberKey()))
                 .willReturn(CareRole.MANAGER);
         given(moreMenuFactory.getMenu(MoreMenuContextType.MANAGER)).willReturn(expected);
 
@@ -75,10 +76,11 @@ class MoreMenuServiceTest {
     @DisplayName("주보호자는 wardKey로 주보호자 메뉴를 조회한다")
     void getMenu_returns_guardian_menu() {
         MoreMenuInfo expected = menu(MoreMenuContextType.GUARDIAN);
+        var guardian = CareFixture.createGuardianMember();
 
         given(memberReader.findByMemberKey(CareFixture.GUARDIAN_MEMBER_KEY))
-                .willReturn(CareFixture.createGuardianMember());
-        given(careRelationshipReader.findCareRole(CareFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY))
+                .willReturn(guardian);
+        given(careRelationshipReader.findCareRole(CareFixture.WARD_MEMBER_KEY, guardian.getMemberKey()))
                 .willReturn(CareRole.GUARDIAN);
         given(moreMenuFactory.getMenu(MoreMenuContextType.GUARDIAN)).willReturn(expected);
 

--- a/src/test/java/com/recaring/moremenu/controller/MoreMenuControllerTest.java
+++ b/src/test/java/com/recaring/moremenu/controller/MoreMenuControllerTest.java
@@ -12,6 +12,7 @@ import com.recaring.support.AbstractIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -19,6 +20,7 @@ import org.springframework.http.HttpHeaders;
 import java.util.Date;
 
 @DisplayName("더보기 메뉴 컨트롤러 HTTP 통합 테스트")
+@Tag("integration")
 class MoreMenuControllerTest extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/recaring/moremenu/controller/MoreMenuControllerTest.java
+++ b/src/test/java/com/recaring/moremenu/controller/MoreMenuControllerTest.java
@@ -1,0 +1,197 @@
+package com.recaring.moremenu.controller;
+
+import com.recaring.care.dataaccess.entity.CareRelationship;
+import com.recaring.care.dataaccess.entity.CareRole;
+import com.recaring.care.dataaccess.repository.CareRelationshipRepository;
+import com.recaring.care.fixture.CareFixture;
+import com.recaring.member.dataaccess.entity.Member;
+import com.recaring.member.dataaccess.repository.MemberRepository;
+import com.recaring.security.jwt.JwtGenerator;
+import com.recaring.security.vo.TokenPayload;
+import com.recaring.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+
+import java.util.Date;
+
+@DisplayName("더보기 메뉴 컨트롤러 HTTP 통합 테스트")
+class MoreMenuControllerTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CareRelationshipRepository careRelationshipRepository;
+
+    @Autowired
+    private JwtGenerator jwtGenerator;
+
+    private Member ward;
+    private Member guardian;
+    private Member manager;
+
+    @BeforeEach
+    void setUp() {
+        ward = memberRepository.save(CareFixture.createWardMember("01010000001"));
+        guardian = memberRepository.save(CareFixture.createGuardianMember("01010000002"));
+        manager = memberRepository.save(CareFixture.createGuardianMember("01010000003"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        careRelationshipRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/more/menu - 인증 없이 요청하면 401을 반환한다")
+    void getMenu_without_auth_returns_401() {
+        client.get()
+                .uri("/api/v1/more/menu")
+                .exchange()
+                .expectStatus().isUnauthorized()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("ERROR")
+                .jsonPath("$.error.errorCode").isEqualTo("E401");
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/more/menu - 보호 대상자는 wardKey 없이 메뉴를 조회한다")
+    void getMenu_returns_ward_menu() {
+        client.get()
+                .uri("/api/v1/more/menu")
+                .header(HttpHeaders.AUTHORIZATION, bearerToken(ward))
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("SUCCESS")
+                .jsonPath("$.data.contextType").isEqualTo("WARD")
+                .jsonPath("$.data.sections[0].sectionKey").isEqualTo("SETTING")
+                .jsonPath("$.data.sections[0].items[0].itemKey").isEqualTo("NOTIFICATION_SETTING")
+                .jsonPath("$.data.sections[0].items[1].itemKey").isEqualTo("PROTECTOR_SETTING");
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/more/menu - 주보호자는 wardKey로 모든 설정이 활성화된 메뉴를 조회한다")
+    void getMenu_returns_guardian_menu() {
+        careRelationshipRepository.save(CareRelationship.of(
+                ward.getMemberKey(), guardian.getMemberKey(), CareRole.GUARDIAN));
+
+        client.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/api/v1/more/menu")
+                        .queryParam("wardKey", ward.getMemberKey())
+                        .build())
+                .header(HttpHeaders.AUTHORIZATION, bearerToken(guardian))
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("SUCCESS")
+                .jsonPath("$.data.contextType").isEqualTo("GUARDIAN")
+                .jsonPath("$.data.sections[0].items[0].itemKey").isEqualTo("LOCATION_COLLECTION_SETTING")
+                .jsonPath("$.data.sections[0].items[0].enabled").isEqualTo(true)
+                .jsonPath("$.data.sections[0].items[2].itemKey").isEqualTo("SAFE_ZONE_SETTING")
+                .jsonPath("$.data.sections[0].items[2].enabled").isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/more/menu - 관리자는 위치 관련 설정이 비활성화된 메뉴를 조회한다")
+    void getMenu_returns_manager_menu() {
+        careRelationshipRepository.save(CareRelationship.of(
+                ward.getMemberKey(), manager.getMemberKey(), CareRole.MANAGER));
+
+        client.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/api/v1/more/menu")
+                        .queryParam("wardKey", ward.getMemberKey())
+                        .build())
+                .header(HttpHeaders.AUTHORIZATION, bearerToken(manager))
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("SUCCESS")
+                .jsonPath("$.data.contextType").isEqualTo("MANAGER")
+                .jsonPath("$.data.sections[0].items[0].itemKey").isEqualTo("LOCATION_COLLECTION_SETTING")
+                .jsonPath("$.data.sections[0].items[0].enabled").isEqualTo(false)
+                .jsonPath("$.data.sections[0].items[2].itemKey").isEqualTo("SAFE_ZONE_SETTING")
+                .jsonPath("$.data.sections[0].items[2].enabled").isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/more/menu - 보호자는 wardKey가 없으면 400을 반환한다")
+    void getMenu_guardian_without_ward_key_returns_400() {
+        client.get()
+                .uri("/api/v1/more/menu")
+                .header(HttpHeaders.AUTHORIZATION, bearerToken(guardian))
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("ERROR")
+                .jsonPath("$.error.errorCode").isEqualTo("E5010");
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/more/menu - 보호자는 wardKey가 공백이면 400을 반환한다")
+    void getMenu_guardian_with_blank_ward_key_returns_400() {
+        client.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/api/v1/more/menu")
+                        .queryParam("wardKey", " ")
+                        .build())
+                .header(HttpHeaders.AUTHORIZATION, bearerToken(guardian))
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("ERROR")
+                .jsonPath("$.error.errorCode").isEqualTo("E5010");
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/more/menu - 관계 없는 wardKey면 403을 반환한다")
+    void getMenu_guardian_with_unrelated_ward_key_returns_403() {
+        client.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/api/v1/more/menu")
+                        .queryParam("wardKey", ward.getMemberKey())
+                        .build())
+                .header(HttpHeaders.AUTHORIZATION, bearerToken(guardian))
+                .exchange()
+                .expectStatus().isForbidden()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("ERROR")
+                .jsonPath("$.error.errorCode").isEqualTo("E6001");
+    }
+
+    @Test
+    @DisplayName("GET /v3/api-docs - Swagger 문서에 더보기 메뉴 API 계약이 노출된다")
+    void openApi_docs_include_more_menu_operation() {
+        client.get()
+                .uri("/v3/api-docs")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.paths['/api/v1/more/menu'].get.summary").isEqualTo("Get more menu")
+                .jsonPath("$.paths['/api/v1/more/menu'].get.parameters[0].name").isEqualTo("wardKey")
+                .jsonPath("$.paths['/api/v1/more/menu'].get.parameters[0].required").isEqualTo(false)
+                .jsonPath("$.components.securitySchemes.BearerAuth.scheme").isEqualTo("bearer");
+    }
+
+    @Test
+    @DisplayName("GET /swagger-ui/index.html - Swagger UI에 접근할 수 있다")
+    void swagger_ui_is_accessible() {
+        client.get()
+                .uri("/swagger-ui/index.html")
+                .exchange()
+                .expectStatus().isOk();
+    }
+
+    private String bearerToken(Member member) {
+        return "Bearer " + jwtGenerator.generateJwt(
+                new TokenPayload(member.getMemberKey(), member.getRole(), new Date())
+        ).accessToken();
+    }
+}

--- a/src/test/java/com/recaring/moremenu/controller/MoreMenuControllerWebMvcTest.java
+++ b/src/test/java/com/recaring/moremenu/controller/MoreMenuControllerWebMvcTest.java
@@ -1,0 +1,146 @@
+package com.recaring.moremenu.controller;
+
+import com.recaring.moremenu.business.MoreMenuContextType;
+import com.recaring.moremenu.business.MoreMenuInfo;
+import com.recaring.moremenu.business.MoreMenuItemInfo;
+import com.recaring.moremenu.business.MoreMenuItemKey;
+import com.recaring.moremenu.business.MoreMenuSectionInfo;
+import com.recaring.moremenu.business.MoreMenuSectionKey;
+import com.recaring.moremenu.business.MoreMenuService;
+import com.recaring.moremenu.business.MoreMenuTargetType;
+import com.recaring.security.vo.AuthMember;
+import com.recaring.common.controller.ApiControllerAdvice;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import io.swagger.v3.oas.annotations.Operation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("더보기 메뉴 컨트롤러 MVC 테스트")
+class MoreMenuControllerWebMvcTest {
+
+    private static final String MEMBER_KEY = "member-key";
+    private static final String WARD_KEY = "ward-key";
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private MoreMenuService moreMenuService;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new MoreMenuController(moreMenuService))
+                .setControllerAdvice(new ApiControllerAdvice())
+                .setCustomArgumentResolvers(authMemberArgumentResolver())
+                .build();
+    }
+
+    @Test
+    @DisplayName("인증 principal과 wardKey를 서비스로 전달하고 API 응답으로 감싼다")
+    void getMenu_returns_api_response() throws Exception {
+        given(moreMenuService.getMenu(MEMBER_KEY, WARD_KEY))
+                .willReturn(menu());
+
+        mockMvc.perform(get("/api/v1/more/menu")
+                        .param("wardKey", WARD_KEY)
+                        .requestAttr("memberKey", MEMBER_KEY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultType").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.contextType").value("GUARDIAN"))
+                .andExpect(jsonPath("$.data.sections[0].sectionKey").value("SETTING"))
+                .andExpect(jsonPath("$.data.sections[0].items[0].itemKey").value("NOTIFICATION_SETTING"))
+                .andExpect(jsonPath("$.data.sections[0].items[0].enabled").value(true))
+                .andExpect(jsonPath("$.data.sections[0].items[0].targetType").value("SCREEN"))
+                .andExpect(jsonPath("$.data.sections[0].items[0].target").value("ST-003"));
+
+        then(moreMenuService).should().getMenu(MEMBER_KEY, WARD_KEY);
+    }
+
+    @Test
+    @DisplayName("서비스 예외는 공통 에러 응답으로 변환된다")
+    void getMenu_returns_error_response_when_service_throws_exception() throws Exception {
+        given(moreMenuService.getMenu(MEMBER_KEY, null))
+                .willThrow(new AppException(ErrorType.WARD_KEY_REQUIRED));
+
+        mockMvc.perform(get("/api/v1/more/menu")
+                        .requestAttr("memberKey", MEMBER_KEY))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resultType").value("ERROR"))
+                .andExpect(jsonPath("$.error.errorCode").value("E5010"));
+    }
+
+    @Test
+    @DisplayName("Swagger 문서는 인증 principal을 숨기고 wardKey만 요청 파라미터로 노출한다")
+    void getMenu_has_swagger_contract() throws NoSuchMethodException {
+        Method method = MoreMenuController.class.getMethod("getMenu", String.class, String.class);
+
+        Operation operation = method.getAnnotation(Operation.class);
+        io.swagger.v3.oas.annotations.Parameter authParameter =
+                method.getParameters()[0].getAnnotation(io.swagger.v3.oas.annotations.Parameter.class);
+        io.swagger.v3.oas.annotations.Parameter wardKeyParameter =
+                method.getParameters()[1].getAnnotation(io.swagger.v3.oas.annotations.Parameter.class);
+
+        assertThat(operation.summary()).isEqualTo("Get more menu");
+        assertThat(authParameter.hidden()).isTrue();
+        assertThat(wardKeyParameter.required()).isFalse();
+        assertThat(wardKeyParameter.description()).contains("Ward member key");
+    }
+
+    private MoreMenuInfo menu() {
+        return new MoreMenuInfo(
+                MoreMenuContextType.GUARDIAN,
+                List.of(new MoreMenuSectionInfo(
+                        MoreMenuSectionKey.SETTING,
+                        List.of(new MoreMenuItemInfo(
+                                MoreMenuItemKey.NOTIFICATION_SETTING,
+                                true,
+                                MoreMenuTargetType.SCREEN,
+                                "ST-003"
+                        ))
+                ))
+        );
+    }
+
+    private HandlerMethodArgumentResolver authMemberArgumentResolver() {
+        return new HandlerMethodArgumentResolver() {
+            @Override
+            public boolean supportsParameter(MethodParameter parameter) {
+                return parameter.hasParameterAnnotation(AuthMember.class)
+                        && parameter.getParameterType().equals(String.class);
+            }
+
+            @Override
+            public Object resolveArgument(
+                    MethodParameter parameter,
+                    ModelAndViewContainer mavContainer,
+                    NativeWebRequest webRequest,
+                    WebDataBinderFactory binderFactory
+            ) {
+                return webRequest.getAttribute("memberKey", RequestAttributes.SCOPE_REQUEST);
+            }
+        };
+    }
+}

--- a/src/test/java/com/recaring/moremenu/implement/MoreMenuFactoryTest.java
+++ b/src/test/java/com/recaring/moremenu/implement/MoreMenuFactoryTest.java
@@ -2,6 +2,7 @@ package com.recaring.moremenu.implement;
 
 import com.recaring.moremenu.business.MoreMenuInfo;
 import com.recaring.moremenu.business.MoreMenuItemInfo;
+import com.recaring.moremenu.business.MoreMenuItemKey;
 import com.recaring.moremenu.business.MoreMenuSectionInfo;
 import com.recaring.moremenu.business.MoreMenuSectionKey;
 import com.recaring.moremenu.business.MoreMenuTargetType;
@@ -119,7 +120,7 @@ class MoreMenuFactoryTest {
                 .orElseThrow();
     }
 
-    private MoreMenuItemInfo find(List<MoreMenuItemInfo> items, com.recaring.moremenu.business.MoreMenuItemKey itemKey) {
+    private MoreMenuItemInfo find(List<MoreMenuItemInfo> items, MoreMenuItemKey itemKey) {
         return items.stream()
                 .filter(item -> item.itemKey() == itemKey)
                 .findFirst()

--- a/src/test/java/com/recaring/moremenu/implement/MoreMenuFactoryTest.java
+++ b/src/test/java/com/recaring/moremenu/implement/MoreMenuFactoryTest.java
@@ -1,0 +1,128 @@
+package com.recaring.moremenu.implement;
+
+import com.recaring.moremenu.business.MoreMenuInfo;
+import com.recaring.moremenu.business.MoreMenuItemInfo;
+import com.recaring.moremenu.business.MoreMenuSectionInfo;
+import com.recaring.moremenu.business.MoreMenuSectionKey;
+import com.recaring.moremenu.business.MoreMenuTargetType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.recaring.moremenu.business.MoreMenuContextType.GUARDIAN;
+import static com.recaring.moremenu.business.MoreMenuContextType.MANAGER;
+import static com.recaring.moremenu.business.MoreMenuContextType.WARD;
+import static com.recaring.moremenu.business.MoreMenuItemKey.APP_VERSION;
+import static com.recaring.moremenu.business.MoreMenuItemKey.CAREGIVER_SETTING;
+import static com.recaring.moremenu.business.MoreMenuItemKey.FAQ;
+import static com.recaring.moremenu.business.MoreMenuItemKey.INQUIRY;
+import static com.recaring.moremenu.business.MoreMenuItemKey.LOCATION_COLLECTION_SETTING;
+import static com.recaring.moremenu.business.MoreMenuItemKey.NOTIFICATION_SETTING;
+import static com.recaring.moremenu.business.MoreMenuItemKey.PROTECTOR_SETTING;
+import static com.recaring.moremenu.business.MoreMenuItemKey.SAFE_ZONE_SETTING;
+import static com.recaring.moremenu.business.MoreMenuItemKey.SIGN_OUT;
+import static com.recaring.moremenu.business.MoreMenuItemKey.TERMS;
+import static com.recaring.moremenu.business.MoreMenuItemKey.WARD_SETTING;
+import static com.recaring.moremenu.business.MoreMenuItemKey.WITHDRAW_ACCOUNT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("더보기 메뉴 팩토리 단위 테스트")
+class MoreMenuFactoryTest {
+
+    private final MoreMenuFactory moreMenuFactory = new MoreMenuFactory();
+
+    @Test
+    @DisplayName("보호 대상자 메뉴는 알림 설정과 보호자 설정을 반환한다")
+    void getMenu_returns_ward_items() {
+        MoreMenuInfo result = moreMenuFactory.getMenu(WARD);
+
+        assertThat(settingItems(result))
+                .extracting(MoreMenuItemInfo::itemKey)
+                .containsExactly(NOTIFICATION_SETTING, PROTECTOR_SETTING);
+        assertCommonMoreItems(result);
+    }
+
+    @Test
+    @DisplayName("관리자 메뉴는 위치 관련 설정을 비활성화한다")
+    void getMenu_returns_manager_items() {
+        List<MoreMenuItemInfo> settingItems = settingItems(moreMenuFactory.getMenu(MANAGER));
+
+        assertThat(settingItems)
+                .extracting(MoreMenuItemInfo::itemKey)
+                .containsExactly(
+                        LOCATION_COLLECTION_SETTING,
+                        NOTIFICATION_SETTING,
+                        SAFE_ZONE_SETTING,
+                        WARD_SETTING,
+                        CAREGIVER_SETTING
+                );
+        assertThat(find(settingItems, LOCATION_COLLECTION_SETTING).enabled()).isFalse();
+        assertThat(find(settingItems, SAFE_ZONE_SETTING).enabled()).isFalse();
+        assertThat(find(settingItems, NOTIFICATION_SETTING).enabled()).isTrue();
+        assertThat(find(settingItems, WARD_SETTING).enabled()).isTrue();
+        assertThat(find(settingItems, CAREGIVER_SETTING).enabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("주보호자 메뉴는 모든 설정 항목을 활성화한다")
+    void getMenu_returns_guardian_items() {
+        List<MoreMenuItemInfo> settingItems = settingItems(moreMenuFactory.getMenu(GUARDIAN));
+
+        assertThat(settingItems)
+                .extracting(MoreMenuItemInfo::itemKey)
+                .containsExactly(
+                        LOCATION_COLLECTION_SETTING,
+                        NOTIFICATION_SETTING,
+                        SAFE_ZONE_SETTING,
+                        WARD_SETTING,
+                        CAREGIVER_SETTING
+                );
+        assertThat(settingItems).allMatch(MoreMenuItemInfo::enabled);
+    }
+
+    @Test
+    @DisplayName("공통 더보기 메뉴는 고객지원 항목과 계정 액션을 반환한다")
+    void getMenu_returns_common_more_items() {
+        MoreMenuInfo result = moreMenuFactory.getMenu(GUARDIAN);
+
+        assertThat(moreItems(result))
+                .extracting(MoreMenuItemInfo::itemKey)
+                .containsExactly(FAQ, TERMS, INQUIRY, APP_VERSION, SIGN_OUT, WITHDRAW_ACCOUNT);
+        assertThat(find(moreItems(result), FAQ).targetType()).isEqualTo(MoreMenuTargetType.WEBVIEW);
+        assertThat(find(moreItems(result), TERMS).targetType()).isEqualTo(MoreMenuTargetType.WEBVIEW);
+        assertThat(find(moreItems(result), INQUIRY).targetType()).isEqualTo(MoreMenuTargetType.EXTERNAL_LINK);
+        assertThat(find(moreItems(result), APP_VERSION).targetType()).isEqualTo(MoreMenuTargetType.CLIENT_ACTION);
+        assertThat(find(moreItems(result), SIGN_OUT).targetType()).isEqualTo(MoreMenuTargetType.ACTION);
+    }
+
+    private void assertCommonMoreItems(MoreMenuInfo result) {
+        assertThat(moreItems(result))
+                .extracting(MoreMenuItemInfo::itemKey)
+                .containsExactly(FAQ, TERMS, INQUIRY, APP_VERSION, SIGN_OUT, WITHDRAW_ACCOUNT);
+    }
+
+    private List<MoreMenuItemInfo> settingItems(MoreMenuInfo menu) {
+        return sectionItems(menu, MoreMenuSectionKey.SETTING);
+    }
+
+    private List<MoreMenuItemInfo> moreItems(MoreMenuInfo menu) {
+        return sectionItems(menu, MoreMenuSectionKey.MORE);
+    }
+
+    private List<MoreMenuItemInfo> sectionItems(MoreMenuInfo menu, MoreMenuSectionKey sectionKey) {
+        return menu.sections()
+                .stream()
+                .filter(section -> section.sectionKey() == sectionKey)
+                .findFirst()
+                .map(MoreMenuSectionInfo::items)
+                .orElseThrow();
+    }
+
+    private MoreMenuItemInfo find(List<MoreMenuItemInfo> items, com.recaring.moremenu.business.MoreMenuItemKey itemKey) {
+        return items.stream()
+                .filter(item -> item.itemKey() == itemKey)
+                .findFirst()
+                .orElseThrow();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
> feature [ST-001]

## 요약
ST-001 더보기 메뉴 화면에서 사용할 메뉴 조회 API를 추가했습니다.  
로그인한 회원의 역할과 선택된 보호 대상자와의 관계에 따라 `WARD`, `MANAGER`, `GUARDIAN` 컨텍스트를 구분하고, 각 컨텍스트에 맞는 메뉴 섹션과 항목을 반환하도록 구현했습니다.

## 변경사항(상세)

### 더보기 메뉴 API 추가
- `GET /api/v1/more/menu` 엔드포인트 추가
- 인증된 회원 기준으로 더보기 메뉴 정보 반환
- 보호자/관리자 컨텍스트에서는 `wardKey`를 통해 보호 대상자와의 관계 확인
- Swagger 문서에 More menu API 계약 추가

### 컨텍스트별 메뉴 구성
- `WARD`, `MANAGER`, `GUARDIAN` 컨텍스트 타입 추가
- 설정/더보기 섹션 및 메뉴 아이템 key 정의
- 메뉴 아이템별 target type 지원
  - `SCREEN`
  - `WEBVIEW`
  - `EXTERNAL_LINK`
  - `ACTION`
  - `CLIENT_ACTION`

### 역할 기반 메뉴 정책 적용
- 보호 대상자
  - 알림 설정
  - 보호자 설정
- 관리자
  - 위치 수집 설정 비활성화
  - 안심존 설정 비활성화
  - 대상자/보호자 관련 설정 제공
- 주보호자
  - 위치 수집 설정 및 안심존 설정 포함 전체 설정 활성화

### 케어 관계 조회 기능 추가
- `CareRelationshipReader.findCareRole()` 추가
- 특정 보호 대상자와 보호자/관리자 간의 관계 역할 조회
- 관계가 없는 경우 `NOT_CARE_RELATED_WARD` 예외 처리

### 테스트 추가
- 더보기 메뉴 서비스 단위 테스트
- 더보기 메뉴 팩토리 단위 테스트
- 더보기 메뉴 컨트롤러 MVC 테스트
- 더보기 메뉴 HTTP 통합 테스트
- 케어 관계 역할 조회 단위 테스트
- Swagger 보안 스키마 및 API 문서 노출 테스트

## Test plan
- [ ] `./gradlew test` 실행
- [ ] 인증 없이 `GET /api/v1/more/menu` 요청 시 401 응답 확인
- [ ] 보호 대상자가 `wardKey` 없이 메뉴 조회 가능한지 확인
- [ ] 주보호자가 `wardKey`로 전체 활성화 메뉴를 조회하는지 확인
- [ ] 관리자가 `wardKey`로 위치 관련 설정이 비활성화된 메뉴를 조회하는지 확인
- [ ] 보호자/관리자가 `wardKey` 없이 요청할 경우 400 응답 확인
- [ ] 관계 없는 `wardKey` 요청 시 403 응답 확인
- [ ] Swagger UI 및 `/v3/api-docs`에 더보기 메뉴 API가 노출되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* **역할 기반 더보기 메뉴**: 피보호자, 관리자, 보호자의 역할에 따라 맞춤형 메뉴 제공
* **메뉴 API 추가**: 설정, 자주 묻는 질문, 약관, 문의, 앱 버전, 로그아웃, 계정 탈퇴 등의 메뉴 항목 포함
* **관리 기능 개선**: 보호 관계 확인 기능 강화

## 테스트
* 역할별 메뉴 반환 및 접근 제어 검증
* API 통합 테스트 및 문서화 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->