### PR TITLE
[Refactor]: RefreshToken 저장소 Redis → DB 전환 

### DIFF
--- a/src/main/generated/com/recaring/auth/dataaccess/entity/QRefreshToken.java
+++ b/src/main/generated/com/recaring/auth/dataaccess/entity/QRefreshToken.java
@@ -1,0 +1,48 @@
+package com.recaring.auth.dataaccess.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.dsl.StringTemplate;
+
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.annotations.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QRefreshToken is a Querydsl query type for RefreshToken
+ */
+@SuppressWarnings("this-escape")
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRefreshToken extends EntityPathBase<RefreshToken> {
+
+    private static final long serialVersionUID = 1461550127L;
+
+    public static final QRefreshToken refreshToken = new QRefreshToken("refreshToken");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> expiredAt = createDateTime("expiredAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath memberKey = createString("memberKey");
+
+    public final StringPath token = createString("token");
+
+    public QRefreshToken(String variable) {
+        super(RefreshToken.class, forVariable(variable));
+    }
+
+    public QRefreshToken(Path<? extends RefreshToken> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QRefreshToken(PathMetadata metadata) {
+        super(RefreshToken.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/recaring/auth/dataaccess/entity/RefreshToken.java
+++ b/src/main/java/com/recaring/auth/dataaccess/entity/RefreshToken.java
@@ -1,0 +1,53 @@
+package com.recaring.auth.dataaccess.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+// TODO: CREATE INDEX idx_refresh_token_token ON refresh_token(token);
+// TODO: CREATE INDEX idx_refresh_token_member_key ON refresh_token(member_key);
+@Getter
+@Entity
+@Table(name = "refresh_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id")
+    private Long id;
+
+    @Column(name = "member_key", nullable = false, length = 36)
+    private String memberKey;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private RefreshToken(String memberKey, String token, LocalDateTime expiredAt) {
+        this.memberKey = memberKey;
+        this.token = token;
+        this.expiredAt = expiredAt;
+    }
+
+    public static RefreshToken of(String memberKey, String token, long expirationMs) {
+        LocalDateTime expiredAt = LocalDateTime.now().plusSeconds(expirationMs / 1000);
+        return new RefreshToken(memberKey, token, expiredAt);
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiredAt);
+    }
+}

--- a/src/main/java/com/recaring/auth/dataaccess/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/recaring/auth/dataaccess/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.recaring.auth.dataaccess.repository;
+
+import com.recaring.auth.dataaccess.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByToken(String token);
+}

--- a/src/main/java/com/recaring/auth/implement/RefreshTokenReader.java
+++ b/src/main/java/com/recaring/auth/implement/RefreshTokenReader.java
@@ -1,24 +1,27 @@
 package com.recaring.auth.implement;
 
+import com.recaring.auth.dataaccess.entity.RefreshToken;
+import com.recaring.auth.dataaccess.repository.RefreshTokenRepository;
 import com.recaring.support.exception.AppException;
 import com.recaring.support.exception.ErrorType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class RefreshTokenReader {
 
-    private static final String KEY_PREFIX = "refresh:token:";
-
-    private final StringRedisTemplate redisTemplate;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public String findMemberKey(String refreshToken) {
-        String memberKey = redisTemplate.opsForValue().get(KEY_PREFIX + refreshToken);
-        if (memberKey == null) {
+        RefreshToken entity = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new AppException(ErrorType.EXPIRED_JWT));
+
+        if (entity.isExpired()) {
+            refreshTokenRepository.deleteByToken(refreshToken);
             throw new AppException(ErrorType.EXPIRED_JWT);
         }
-        return memberKey;
+
+        return entity.getMemberKey();
     }
 }

--- a/src/main/java/com/recaring/auth/implement/RefreshTokenWriter.java
+++ b/src/main/java/com/recaring/auth/implement/RefreshTokenWriter.java
@@ -1,33 +1,26 @@
 package com.recaring.auth.implement;
 
+import com.recaring.auth.dataaccess.entity.RefreshToken;
+import com.recaring.auth.dataaccess.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor
 public class RefreshTokenWriter {
 
-    private static final String KEY_PREFIX = "refresh:token:";
-
     @Value("${jwt.refresh.expiration}")
     private long refreshExpiration; // ms 단위
 
-    private final StringRedisTemplate redisTemplate;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public void save(String refreshToken, String memberKey) {
-        redisTemplate.opsForValue().set(
-                KEY_PREFIX + refreshToken,
-                memberKey,
-                refreshExpiration,
-                TimeUnit.MILLISECONDS
-        );
+        RefreshToken entity = RefreshToken.of(memberKey, refreshToken, refreshExpiration);
+        refreshTokenRepository.save(entity);
     }
 
     public void delete(String refreshToken) {
-        redisTemplate.delete(KEY_PREFIX + refreshToken);
+        refreshTokenRepository.deleteByToken(refreshToken);
     }
 }

--- a/src/test/java/com/recaring/auth/business/TokenRefreshServiceTest.java
+++ b/src/test/java/com/recaring/auth/business/TokenRefreshServiceTest.java
@@ -88,7 +88,7 @@ class TokenRefreshServiceTest {
     }
 
     @Test
-    @DisplayName("Redis에 없는 리프레시 토큰이면 EXPIRED_JWT 예외가 발생한다")
+    @DisplayName("DB에 없는 리프레시 토큰이면 EXPIRED_JWT 예외가 발생한다")
     void refresh_fail_when_token_not_in_redis() {
         String refreshToken = "not-in-redis-token";
         @SuppressWarnings("unchecked")

--- a/src/test/java/com/recaring/auth/fixture/AuthFixture.java
+++ b/src/test/java/com/recaring/auth/fixture/AuthFixture.java
@@ -1,6 +1,7 @@
 package com.recaring.auth.fixture;
 
 import com.recaring.auth.business.command.SignUpCommand;
+import com.recaring.auth.dataaccess.entity.RefreshToken;
 import com.recaring.auth.vo.EncodedPassword;
 import com.recaring.auth.vo.LocalEmail;
 import com.recaring.auth.vo.Password;
@@ -17,6 +18,12 @@ public class AuthFixture {
     public static final String ENCODED_PASSWORD = "$2a$10$encoded";
     public static final String ACCESS_TOKEN = "access-token";
     public static final String REFRESH_TOKEN = "refresh-token";
+    public static final String MEMBER_KEY = "test-member-key-uuid";
+    private static final long REFRESH_EXPIRATION_MS = 1209600000L; // 14 days
+
+    public static RefreshToken createRefreshToken() {
+        return RefreshToken.of(MEMBER_KEY, REFRESH_TOKEN, REFRESH_EXPIRATION_MS);
+    }
 
     public static LocalEmail createLocalEmail() {
         return new LocalEmail(EMAIL);

--- a/src/test/java/com/recaring/auth/implement/RefreshTokenReaderTest.java
+++ b/src/test/java/com/recaring/auth/implement/RefreshTokenReaderTest.java
@@ -1,5 +1,8 @@
 package com.recaring.auth.implement;
 
+import com.recaring.auth.dataaccess.entity.RefreshToken;
+import com.recaring.auth.dataaccess.repository.RefreshTokenRepository;
+import com.recaring.auth.fixture.AuthFixture;
 import com.recaring.support.exception.AppException;
 import com.recaring.support.exception.ErrorType;
 import org.junit.jupiter.api.DisplayName;
@@ -8,12 +11,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("RefreshTokenReader 단위 테스트")
@@ -23,60 +30,46 @@ class RefreshTokenReaderTest {
     private RefreshTokenReader refreshTokenReader;
 
     @Mock
-    private StringRedisTemplate redisTemplate;
-
-    @Mock
-    private ValueOperations<String, String> valueOperations;
+    private RefreshTokenRepository refreshTokenRepository;
 
     @Test
-    @DisplayName("리프레시 토큰으로 memberKey 조회 성공")
+    @DisplayName("유효한 토큰으로 memberKey 조회 성공")
     void findMemberKey_success() {
         // given
-        String refreshToken = "valid-refresh-token";
-        String memberKey = "member-key-123";
-        String redisKey = "refresh:token:" + refreshToken;
-
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.get(redisKey)).willReturn(memberKey);
+        RefreshToken entity = AuthFixture.createRefreshToken();
+        given(refreshTokenRepository.findByToken(AuthFixture.REFRESH_TOKEN)).willReturn(Optional.of(entity));
 
         // when
-        String result = refreshTokenReader.findMemberKey(refreshToken);
+        String result = refreshTokenReader.findMemberKey(AuthFixture.REFRESH_TOKEN);
 
         // then
-        assertThat(result).isEqualTo(memberKey);
+        assertThat(result).isEqualTo(AuthFixture.MEMBER_KEY);
     }
 
     @Test
-    @DisplayName("리프레시 토큰으로 memberKey 조회 실패 - 만료된 토큰")
-    void findMemberKey_fail_expired_token() {
+    @DisplayName("DB에 존재하지 않는 토큰이면 EXPIRED_JWT 예외가 발생한다")
+    void findMemberKey_fail_when_not_found() {
         // given
-        String expiredToken = "expired-refresh-token";
-        String redisKey = "refresh:token:" + expiredToken;
-
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.get(redisKey)).willReturn(null);
+        given(refreshTokenRepository.findByToken(AuthFixture.REFRESH_TOKEN)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> refreshTokenReader.findMemberKey(expiredToken))
-            .isInstanceOf(AppException.class)
-            .hasFieldOrPropertyWithValue("errorType", ErrorType.EXPIRED_JWT);
+        assertThatThrownBy(() -> refreshTokenReader.findMemberKey(AuthFixture.REFRESH_TOKEN))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.EXPIRED_JWT);
     }
 
     @Test
-    @DisplayName("리프레시 토큰으로 memberKey 조회 - Redis 키 프리픽스 검증")
-    void findMemberKey_redis_key_prefix() {
+    @DisplayName("만료된 토큰이면 DB에서 삭제 후 EXPIRED_JWT 예외가 발생한다")
+    void findMemberKey_fail_when_expired() {
         // given
-        String refreshToken = "token-abc-123";
-        String memberKey = "member-xyz-789";
-        String expectedRedisKey = "refresh:token:token-abc-123";
+        RefreshToken expiredToken = AuthFixture.createRefreshToken();
+        ReflectionTestUtils.setField(expiredToken, "expiredAt", LocalDateTime.now().minusDays(1));
+        given(refreshTokenRepository.findByToken(AuthFixture.REFRESH_TOKEN)).willReturn(Optional.of(expiredToken));
 
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.get(expectedRedisKey)).willReturn(memberKey);
-
-        // when
-        String result = refreshTokenReader.findMemberKey(refreshToken);
-
-        // then
-        assertThat(result).isEqualTo(memberKey);
+        // when & then
+        assertThatThrownBy(() -> refreshTokenReader.findMemberKey(AuthFixture.REFRESH_TOKEN))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.EXPIRED_JWT);
+        then(refreshTokenRepository).should(times(1)).deleteByToken(AuthFixture.REFRESH_TOKEN);
     }
 }

--- a/src/test/java/com/recaring/auth/implement/RefreshTokenWriterTest.java
+++ b/src/test/java/com/recaring/auth/implement/RefreshTokenWriterTest.java
@@ -1,21 +1,19 @@
 package com.recaring.auth.implement;
 
+import com.recaring.auth.dataaccess.entity.RefreshToken;
+import com.recaring.auth.dataaccess.repository.RefreshTokenRepository;
+import com.recaring.auth.fixture.AuthFixture;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.util.concurrent.TimeUnit;
-
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
@@ -27,65 +25,34 @@ class RefreshTokenWriterTest {
     private RefreshTokenWriter refreshTokenWriter;
 
     @Mock
-    private StringRedisTemplate redisTemplate;
+    private RefreshTokenRepository refreshTokenRepository;
 
-    @Mock
-    private ValueOperations<String, String> valueOperations;
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(refreshTokenWriter, "refreshExpiration", 1209600000L);
+    }
 
     @Test
-    @DisplayName("리프레시 토큰 저장 성공 - Redis에 memberKey와 함께 저장")
+    @DisplayName("리프레시 토큰을 DB에 저장한다")
     void save_success() {
-        // given
-        String refreshToken = "refresh-token-123";
-        String memberKey = "member-key-456";
-        long refreshExpiration = 1209600000; // 14 days in milliseconds
-
-        ReflectionTestUtils.setField(refreshTokenWriter, "refreshExpiration", refreshExpiration);
-
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-
         // when
-        refreshTokenWriter.save(refreshToken, memberKey);
+        refreshTokenWriter.save(AuthFixture.REFRESH_TOKEN, AuthFixture.MEMBER_KEY);
 
         // then
-        then(redisTemplate).should(times(1)).opsForValue();
-        then(valueOperations).should(times(1))
-            .set("refresh:token:" + refreshToken, memberKey, refreshExpiration, TimeUnit.MILLISECONDS);
+        ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
+        then(refreshTokenRepository).should(times(1)).save(captor.capture());
+        assertThat(captor.getValue().getMemberKey()).isEqualTo(AuthFixture.MEMBER_KEY);
+        assertThat(captor.getValue().getToken()).isEqualTo(AuthFixture.REFRESH_TOKEN);
+        assertThat(captor.getValue().isExpired()).isFalse();
     }
 
     @Test
-    @DisplayName("리프레시 토큰 삭제 성공 - Redis에서 토큰 제거")
+    @DisplayName("리프레시 토큰을 DB에서 삭제한다")
     void delete_success() {
-        // given
-        String refreshToken = "refresh-token-to-delete";
-        String redisKey = "refresh:token:" + refreshToken;
-
-        given(redisTemplate.delete(redisKey)).willReturn(true);
-
         // when
-        refreshTokenWriter.delete(refreshToken);
+        refreshTokenWriter.delete(AuthFixture.REFRESH_TOKEN);
 
         // then
-        then(redisTemplate).should(times(1)).delete(redisKey);
-    }
-
-    @Test
-    @DisplayName("리프레시 토큰 저장 - 올바른 Redis 키 프리픽스 사용")
-    void save_redis_key_prefix() {
-        // given
-        String refreshToken = "token-prefix-test";
-        String memberKey = "member-123";
-        long expiration = 1209600000;
-        String expectedKey = "refresh:token:token-prefix-test";
-
-        ReflectionTestUtils.setField(refreshTokenWriter, "refreshExpiration", expiration);
-        org.mockito.Mockito.when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-
-        // when
-        refreshTokenWriter.save(refreshToken, memberKey);
-
-        // then
-        then(valueOperations).should(times(1))
-            .set(expectedKey, memberKey, expiration, TimeUnit.MILLISECONDS);
+        then(refreshTokenRepository).should(times(1)).deleteByToken(AuthFixture.REFRESH_TOKEN);
     }
 }


### PR DESCRIPTION
## 개요
RefreshToken 저장소를 Redis에서 DB(PostgreSQL)로 전환했습니다.
만료 토큰 자동 삭제 로직을 포함하며, 기존 Redis 의존성을 제거하고 JPA Repository 기반으로 교체했습니다.

## 변경 사항
- RefreshToken Entity 신규 생성 (auth/dataaccess/entity/)
- RefreshTokenRepository 신규 생성 (auth/dataaccess/repository/)
- RefreshTokenWriter: StringRedisTemplate 제거, RefreshTokenRepository로 교체
- RefreshTokenReader: StringRedisTemplate 제거, RefreshTokenRepository로 교체 (만료 토큰 자동 삭제 포함)
- AuthFixture: MEMBER_KEY, createRefreshToken() 추가
- RefreshTokenWriterTest: Redis 기반 테스트 -> Repository 기반으로 완전 교체
- RefreshTokenReaderTest: Redis 기반 테스트 -> Repository 기반으로 완전 교체 (만료 케이스 포함)
- TokenRefreshServiceTest: display name 수정

## 관련 이슈
closes #83

## 테스트
- [x] 단위 테스트 통과 (./gradlew test)
- [x] 전체 빌드 성공 (./gradlew build)