### PR TITLE
Feature/82

### DIFF
--- a/.claude/skills/feature-dev/references/snapshot.md
+++ b/.claude/skills/feature-dev/references/snapshot.md
@@ -38,11 +38,11 @@
 | Location | GET | `/api/v1/location/stream/{wardKey}` | SSE 실시간 위치 스트림 (GUARDIAN) |
 | Location | GET | `/api/v1/location/history/{wardKey}` | 날짜별 이동 경로 히스토리 |
 | Member | GET/PATCH | `/api/v1/member/...` | 회원 정보 조회/수정 |
-| SafeZone | POST | `/api/v1/care/wards/{wardKey}/safe-zones` | 안심존 추가 (GUARDIAN) |
-| SafeZone | GET | `/api/v1/care/wards/{wardKey}/safe-zones` | 안심존 목록 조회 (GUARDIAN) |
-| SafeZone | GET | `/api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}` | 안심존 상세 조회 (GUARDIAN) |
-| SafeZone | PATCH | `/api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}` | 안심존 수정 (GUARDIAN) |
-| SafeZone | DELETE | `/api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}` | 안심존 삭제 (GUARDIAN) |
+| SafeZone | POST | `/api/v1/care/wards/{wardKey}/safe-zones` | 안심존 추가 (GUARDIAN only) |
+| SafeZone | GET | `/api/v1/care/wards/{wardKey}/safe-zones` | 안심존 목록 조회 (GUARDIAN, MANAGER) |
+| SafeZone | GET | `/api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}` | 안심존 상세 조회 (GUARDIAN, MANAGER) |
+| SafeZone | PATCH | `/api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}` | 안심존 수정 (GUARDIAN only) |
+| SafeZone | DELETE | `/api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}` | 안심존 삭제 (GUARDIAN only) |
 | SMS | POST | `/api/v1/sms/verification/send` | SMS 인증코드 발송 |
 | SMS | POST | `/api/v1/sms/verification/verify` | SMS 인증코드 검증 |
 

--- a/.claude/skills/feature-dev/references/snapshot.md
+++ b/.claude/skills/feature-dev/references/snapshot.md
@@ -1,6 +1,6 @@
 # 프로젝트 스냅샷
 
-> 마지막 업데이트: 2026-05-04. 기능 추가·수정 시 해당 섹션을 갱신한다.
+> 마지막 업데이트: 2026-05-10. 기능 추가·수정 시 해당 섹션을 갱신한다.
 
 ## 도메인별 패키지 현황
 
@@ -11,6 +11,7 @@
 | `device` | DeviceTokenService | WardDeviceTokenManager, WardDeviceTokenReader |
 | `location` | LocationService | GpsHistoryReader/Writer, GpsLatestCacheReader/Writer, SseEmitterManager, LocationValidator, GpsPatternAnalysisScheduler(SQS 발행) |
 | `member` | MemberService | MemberReader/Writer/Validator |
+| `safezone` | SafeZoneService | SafeZoneReader, SafeZoneWriter |
 | `sms` | PhoneVerificationService | SmsClient, SmsCodeGenerator, PhoneVerificationReader/Writer |
 
 ## API 엔드포인트
@@ -37,6 +38,11 @@
 | Location | GET | `/api/v1/location/stream/{wardKey}` | SSE 실시간 위치 스트림 (GUARDIAN) |
 | Location | GET | `/api/v1/location/history/{wardKey}` | 날짜별 이동 경로 히스토리 |
 | Member | GET/PATCH | `/api/v1/member/...` | 회원 정보 조회/수정 |
+| SafeZone | POST | `/api/v1/care/wards/{wardKey}/safe-zones` | 안심존 추가 (GUARDIAN) |
+| SafeZone | GET | `/api/v1/care/wards/{wardKey}/safe-zones` | 안심존 목록 조회 (GUARDIAN) |
+| SafeZone | GET | `/api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}` | 안심존 상세 조회 (GUARDIAN) |
+| SafeZone | PATCH | `/api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}` | 안심존 수정 (GUARDIAN) |
+| SafeZone | DELETE | `/api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}` | 안심존 삭제 (GUARDIAN) |
 | SMS | POST | `/api/v1/sms/verification/send` | SMS 인증코드 발송 |
 | SMS | POST | `/api/v1/sms/verification/verify` | SMS 인증코드 검증 |
 
@@ -53,6 +59,7 @@
 | GpsHistory | gps_histories | wardMemberKey, latitude, longitude, recordedAt |
 | WardDeviceToken | ward_device_tokens | wardKey(UUID, UNIQUE), token(UUID, UNIQUE), createdAt, expiresAt |
 | MembersTermsAgreement | members_terms_agreements | memberKey, agreedAt |
+| SafeZone | safe_zones | safeZoneKey(UUID), wardMemberKey, name, address, latitude, longitude, radius(SMALL/MEDIUM/LARGE/XLARGE) |
 
 ## Redis 키 구조
 

--- a/src/main/java/com/recaring/care/dataaccess/repository/custom/CareRelationshipRepositoryCustom.java
+++ b/src/main/java/com/recaring/care/dataaccess/repository/custom/CareRelationshipRepositoryCustom.java
@@ -12,4 +12,6 @@ public interface CareRelationshipRepositoryCustom {
     List<CareRelationship> findAllByCaregiverMemberKey(String caregiverMemberKey);
 
     boolean existsByWardKeyAndCaregiverKeyAndCareRole(String wardKey, String caregiverKey, CareRole careRole);
+
+    boolean existsByWardKeyAndCaregiverKey(String wardKey, String caregiverKey);
 }

--- a/src/main/java/com/recaring/care/dataaccess/repository/custom/CareRelationshipRepositoryCustomImpl.java
+++ b/src/main/java/com/recaring/care/dataaccess/repository/custom/CareRelationshipRepositoryCustomImpl.java
@@ -41,4 +41,16 @@ public class CareRelationshipRepositoryCustomImpl extends QuerydslRepositorySupp
                 .fetchFirst();
         return result != null;
     }
+
+    @Override
+    public boolean existsByWardKeyAndCaregiverKey(String wardKey, String caregiverKey) {
+        Integer result = selectOne()
+                .from(careRelationship)
+                .where(
+                        careRelationship.wardMemberKey.eq(wardKey),
+                        careRelationship.caregiverMemberKey.eq(caregiverKey)
+                )
+                .fetchFirst();
+        return result != null;
+    }
 }

--- a/src/main/java/com/recaring/config/auth/SecurityConfig.java
+++ b/src/main/java/com/recaring/config/auth/SecurityConfig.java
@@ -82,7 +82,13 @@ public class SecurityConfig {
                                 mvc.matcher(HttpMethod.GET,  "/api/v1/care/wards"),
                                 mvc.matcher(HttpMethod.POST, "/api/v1/members/phones"),
                                 mvc.matcher(HttpMethod.GET,  "/api/v1/location/settings/{wardKey}/collection-interval"),
-                                mvc.matcher(HttpMethod.PATCH, "/api/v1/location/settings/{wardKey}/collection-interval")
+                                mvc.matcher(HttpMethod.PATCH, "/api/v1/location/settings/{wardKey}/collection-interval"),
+                                // SafeZone (GUARDIAN/MANAGER 모두 MemberRole.GUARDIAN)
+                                mvc.matcher(HttpMethod.POST,   "/api/v1/care/wards/{wardKey}/safe-zones"),
+                                mvc.matcher(HttpMethod.GET,    "/api/v1/care/wards/{wardKey}/safe-zones"),
+                                mvc.matcher(HttpMethod.GET,    "/api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}"),
+                                mvc.matcher(HttpMethod.PATCH,  "/api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}"),
+                                mvc.matcher(HttpMethod.DELETE, "/api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}")
                         ).hasRole("GUARDIAN")
 
                         // GUARDIAN + WARD 모두 접근 가능

--- a/src/main/java/com/recaring/safezone/business/SafeZoneService.java
+++ b/src/main/java/com/recaring/safezone/business/SafeZoneService.java
@@ -1,0 +1,63 @@
+package com.recaring.safezone.business;
+
+import com.recaring.care.dataaccess.repository.CareRelationshipRepository;
+import com.recaring.safezone.controller.request.CreateSafeZoneCommand;
+import com.recaring.safezone.controller.request.UpdateSafeZoneCommand;
+import com.recaring.safezone.dataaccess.entity.SafeZone;
+import com.recaring.safezone.implement.SafeZoneReader;
+import com.recaring.safezone.implement.SafeZoneWriter;
+import com.recaring.safezone.vo.SafeZoneInfo;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SafeZoneService {
+
+    private final SafeZoneReader safeZoneReader;
+    private final SafeZoneWriter safeZoneWriter;
+    private final CareRelationshipRepository careRelationshipRepository;
+
+    @Transactional
+    public void addSafeZone(String requesterKey, CreateSafeZoneCommand command) {
+        validateCareAccess(requesterKey, command.wardMemberKey());
+        safeZoneWriter.register(command);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SafeZoneInfo> getSafeZones(String requesterKey, String wardKey) {
+        validateCareAccess(requesterKey, wardKey);
+        return safeZoneReader.findAllByWardMemberKey(wardKey);
+    }
+
+    @Transactional(readOnly = true)
+    public SafeZoneInfo getSafeZone(String requesterKey, String wardKey, String safeZoneKey) {
+        validateCareAccess(requesterKey, wardKey);
+        return safeZoneReader.findBySafeZoneKey(safeZoneKey);
+    }
+
+    @Transactional
+    public void updateSafeZone(String requesterKey, String wardKey, String safeZoneKey, UpdateSafeZoneCommand command) {
+        validateCareAccess(requesterKey, wardKey);
+        SafeZone zone = safeZoneReader.getEntity(safeZoneKey);
+        safeZoneWriter.update(zone, command);
+    }
+
+    @Transactional
+    public void deleteSafeZone(String requesterKey, String wardKey, String safeZoneKey) {
+        validateCareAccess(requesterKey, wardKey);
+        SafeZone zone = safeZoneReader.getEntity(safeZoneKey);
+        safeZoneWriter.delete(zone);
+    }
+
+    private void validateCareAccess(String requesterKey, String wardKey) {
+        if (!careRelationshipRepository.existsByWardKeyAndCaregiverKey(wardKey, requesterKey)) {
+            throw new AppException(ErrorType.NOT_CAREGIVER_OF_WARD);
+        }
+    }
+}

--- a/src/main/java/com/recaring/safezone/business/SafeZoneService.java
+++ b/src/main/java/com/recaring/safezone/business/SafeZoneService.java
@@ -1,5 +1,6 @@
 package com.recaring.safezone.business;
 
+import com.recaring.care.dataaccess.entity.CareRole;
 import com.recaring.care.dataaccess.repository.CareRelationshipRepository;
 import com.recaring.safezone.controller.request.CreateSafeZoneCommand;
 import com.recaring.safezone.controller.request.UpdateSafeZoneCommand;
@@ -25,7 +26,7 @@ public class SafeZoneService {
 
     @Transactional
     public void addSafeZone(String requesterKey, CreateSafeZoneCommand command) {
-        validateCareAccess(requesterKey, command.wardMemberKey());
+        validateGuardianAccess(requesterKey, command.wardMemberKey());
         safeZoneWriter.register(command);
     }
 
@@ -43,14 +44,14 @@ public class SafeZoneService {
 
     @Transactional
     public void updateSafeZone(String requesterKey, String wardKey, String safeZoneKey, UpdateSafeZoneCommand command) {
-        validateCareAccess(requesterKey, wardKey);
+        validateGuardianAccess(requesterKey, wardKey);
         SafeZone zone = safeZoneReader.getEntity(safeZoneKey);
         safeZoneWriter.update(zone, command);
     }
 
     @Transactional
     public void deleteSafeZone(String requesterKey, String wardKey, String safeZoneKey) {
-        validateCareAccess(requesterKey, wardKey);
+        validateGuardianAccess(requesterKey, wardKey);
         SafeZone zone = safeZoneReader.getEntity(safeZoneKey);
         safeZoneWriter.delete(zone);
     }
@@ -58,6 +59,12 @@ public class SafeZoneService {
     private void validateCareAccess(String requesterKey, String wardKey) {
         if (!careRelationshipRepository.existsByWardKeyAndCaregiverKey(wardKey, requesterKey)) {
             throw new AppException(ErrorType.NOT_CAREGIVER_OF_WARD);
+        }
+    }
+
+    private void validateGuardianAccess(String requesterKey, String wardKey) {
+        if (!careRelationshipRepository.existsByWardKeyAndCaregiverKeyAndCareRole(wardKey, requesterKey, CareRole.GUARDIAN)) {
+            throw new AppException(ErrorType.NOT_GUARDIAN_OF_WARD);
         }
     }
 }

--- a/src/main/java/com/recaring/safezone/controller/SafeZoneController.java
+++ b/src/main/java/com/recaring/safezone/controller/SafeZoneController.java
@@ -1,0 +1,86 @@
+package com.recaring.safezone.controller;
+
+import com.recaring.safezone.business.SafeZoneService;
+import com.recaring.safezone.controller.request.CreateSafeZoneRequest;
+import com.recaring.safezone.controller.request.UpdateSafeZoneRequest;
+import com.recaring.safezone.controller.response.SafeZoneResponse;
+import com.recaring.security.vo.AuthMember;
+import com.recaring.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/care/wards/{wardKey}/safe-zones")
+@RequiredArgsConstructor
+@Tag(name = "SafeZone", description = "안심존 API (등록, 조회, 수정, 삭제)")
+public class SafeZoneController {
+
+    private final SafeZoneService safeZoneService;
+
+    @Operation(summary = "안심존 추가", description = "보호자/관계자가 보호대상자의 안심존을 추가합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> addSafeZone(
+            @AuthMember String memberKey,
+            @PathVariable String wardKey,
+            @Valid @RequestBody CreateSafeZoneRequest request
+    ) {
+        safeZoneService.addSafeZone(memberKey, request.toCommand(wardKey));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success());
+    }
+
+    @Operation(summary = "안심존 목록 조회", description = "보호대상자에게 등록된 안심존 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<SafeZoneResponse>>> getSafeZones(
+            @AuthMember String memberKey,
+            @PathVariable String wardKey
+    ) {
+        List<SafeZoneResponse> responses = safeZoneService.getSafeZones(memberKey, wardKey)
+                .stream()
+                .map(SafeZoneResponse::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    @Operation(summary = "안심존 상세 조회", description = "안심존 하나의 상세 정보를 조회합니다.")
+    @GetMapping("/{safeZoneKey}")
+    public ResponseEntity<ApiResponse<SafeZoneResponse>> getSafeZone(
+            @AuthMember String memberKey,
+            @PathVariable String wardKey,
+            @PathVariable String safeZoneKey
+    ) {
+        SafeZoneResponse response = SafeZoneResponse.from(
+                safeZoneService.getSafeZone(memberKey, wardKey, safeZoneKey)
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "안심존 수정", description = "안심존의 이름, 주소, 위도, 경도, 반경을 수정합니다.")
+    @PatchMapping("/{safeZoneKey}")
+    public ResponseEntity<ApiResponse<Void>> updateSafeZone(
+            @AuthMember String memberKey,
+            @PathVariable String wardKey,
+            @PathVariable String safeZoneKey,
+            @Valid @RequestBody UpdateSafeZoneRequest request
+    ) {
+        safeZoneService.updateSafeZone(memberKey, wardKey, safeZoneKey, request.toCommand());
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @Operation(summary = "안심존 삭제", description = "안심존을 삭제합니다.")
+    @DeleteMapping("/{safeZoneKey}")
+    public ResponseEntity<ApiResponse<Void>> deleteSafeZone(
+            @AuthMember String memberKey,
+            @PathVariable String wardKey,
+            @PathVariable String safeZoneKey
+    ) {
+        safeZoneService.deleteSafeZone(memberKey, wardKey, safeZoneKey);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+}

--- a/src/main/java/com/recaring/safezone/controller/request/CreateSafeZoneCommand.java
+++ b/src/main/java/com/recaring/safezone/controller/request/CreateSafeZoneCommand.java
@@ -1,0 +1,13 @@
+package com.recaring.safezone.controller.request;
+
+import com.recaring.safezone.dataaccess.entity.SafeZoneRadius;
+
+public record CreateSafeZoneCommand(
+        String wardMemberKey,
+        String name,
+        String address,
+        double latitude,
+        double longitude,
+        SafeZoneRadius radius
+) {
+}

--- a/src/main/java/com/recaring/safezone/controller/request/CreateSafeZoneRequest.java
+++ b/src/main/java/com/recaring/safezone/controller/request/CreateSafeZoneRequest.java
@@ -1,0 +1,17 @@
+package com.recaring.safezone.controller.request;
+
+import com.recaring.safezone.dataaccess.entity.SafeZoneRadius;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateSafeZoneRequest(
+        @NotBlank String name,
+        @NotBlank String address,
+        @NotNull Double latitude,
+        @NotNull Double longitude,
+        @NotNull SafeZoneRadius radius
+) {
+    public CreateSafeZoneCommand toCommand(String wardMemberKey) {
+        return new CreateSafeZoneCommand(wardMemberKey, name, address, latitude, longitude, radius);
+    }
+}

--- a/src/main/java/com/recaring/safezone/controller/request/UpdateSafeZoneCommand.java
+++ b/src/main/java/com/recaring/safezone/controller/request/UpdateSafeZoneCommand.java
@@ -1,0 +1,12 @@
+package com.recaring.safezone.controller.request;
+
+import com.recaring.safezone.dataaccess.entity.SafeZoneRadius;
+
+public record UpdateSafeZoneCommand(
+        String name,
+        String address,
+        double latitude,
+        double longitude,
+        SafeZoneRadius radius
+) {
+}

--- a/src/main/java/com/recaring/safezone/controller/request/UpdateSafeZoneRequest.java
+++ b/src/main/java/com/recaring/safezone/controller/request/UpdateSafeZoneRequest.java
@@ -1,0 +1,17 @@
+package com.recaring.safezone.controller.request;
+
+import com.recaring.safezone.dataaccess.entity.SafeZoneRadius;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateSafeZoneRequest(
+        @NotBlank String name,
+        @NotBlank String address,
+        @NotNull Double latitude,
+        @NotNull Double longitude,
+        @NotNull SafeZoneRadius radius
+) {
+    public UpdateSafeZoneCommand toCommand() {
+        return new UpdateSafeZoneCommand(name, address, latitude, longitude, radius);
+    }
+}

--- a/src/main/java/com/recaring/safezone/controller/response/SafeZoneResponse.java
+++ b/src/main/java/com/recaring/safezone/controller/response/SafeZoneResponse.java
@@ -1,0 +1,23 @@
+package com.recaring.safezone.controller.response;
+
+import com.recaring.safezone.vo.SafeZoneInfo;
+
+public record SafeZoneResponse(
+        String safeZoneKey,
+        String name,
+        String address,
+        double latitude,
+        double longitude,
+        int radiusMeters
+) {
+    public static SafeZoneResponse from(SafeZoneInfo info) {
+        return new SafeZoneResponse(
+                info.safeZoneKey(),
+                info.name(),
+                info.address(),
+                info.latitude(),
+                info.longitude(),
+                info.radius().getMeters()
+        );
+    }
+}

--- a/src/main/java/com/recaring/safezone/dataaccess/entity/SafeZone.java
+++ b/src/main/java/com/recaring/safezone/dataaccess/entity/SafeZone.java
@@ -1,0 +1,69 @@
+package com.recaring.safezone.dataaccess.entity;
+
+import com.recaring.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "safe_zones")
+@SQLDelete(sql = "UPDATE safe_zones SET deleted_at = NOW() WHERE safe_zone_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SafeZone extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "safe_zone_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String safeZoneKey;
+
+    @Column(nullable = false)
+    private String wardMemberKey;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(nullable = false)
+    private double latitude;
+
+    @Column(nullable = false)
+    private double longitude;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private SafeZoneRadius radius;
+
+    @Builder
+    public SafeZone(String wardMemberKey, String name, String address,
+                    double latitude, double longitude, SafeZoneRadius radius) {
+        this.safeZoneKey = UUID.randomUUID().toString();
+        this.wardMemberKey = wardMemberKey;
+        this.name = name;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.radius = radius;
+    }
+
+    public void update(String name, String address, double latitude, double longitude, SafeZoneRadius radius) {
+        this.name = name;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.radius = radius;
+        update();
+    }
+}

--- a/src/main/java/com/recaring/safezone/dataaccess/entity/SafeZoneRadius.java
+++ b/src/main/java/com/recaring/safezone/dataaccess/entity/SafeZoneRadius.java
@@ -1,0 +1,15 @@
+package com.recaring.safezone.dataaccess.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SafeZoneRadius {
+    SMALL(500),
+    MEDIUM(1000),
+    LARGE(1500),
+    XLARGE(2000);
+
+    private final int meters;
+}

--- a/src/main/java/com/recaring/safezone/dataaccess/repository/SafeZoneRepository.java
+++ b/src/main/java/com/recaring/safezone/dataaccess/repository/SafeZoneRepository.java
@@ -1,0 +1,8 @@
+package com.recaring.safezone.dataaccess.repository;
+
+import com.recaring.safezone.dataaccess.entity.SafeZone;
+import com.recaring.safezone.dataaccess.repository.custom.SafeZoneRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SafeZoneRepository extends JpaRepository<SafeZone, Long>, SafeZoneRepositoryCustom {
+}

--- a/src/main/java/com/recaring/safezone/dataaccess/repository/custom/SafeZoneRepositoryCustom.java
+++ b/src/main/java/com/recaring/safezone/dataaccess/repository/custom/SafeZoneRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.recaring.safezone.dataaccess.repository.custom;
+
+import com.recaring.safezone.dataaccess.entity.SafeZone;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SafeZoneRepositoryCustom {
+
+    List<SafeZone> findAllByWardMemberKey(String wardMemberKey);
+
+    Optional<SafeZone> findBySafeZoneKey(String safeZoneKey);
+}

--- a/src/main/java/com/recaring/safezone/dataaccess/repository/custom/SafeZoneRepositoryCustomImpl.java
+++ b/src/main/java/com/recaring/safezone/dataaccess/repository/custom/SafeZoneRepositoryCustomImpl.java
@@ -1,0 +1,34 @@
+package com.recaring.safezone.dataaccess.repository.custom;
+
+import com.recaring.safezone.dataaccess.entity.SafeZone;
+import com.recaring.support.repository.QuerydslRepositorySupport;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.recaring.safezone.dataaccess.entity.QSafeZone.safeZone;
+
+public class SafeZoneRepositoryCustomImpl extends QuerydslRepositorySupport
+        implements SafeZoneRepositoryCustom {
+
+    protected SafeZoneRepositoryCustomImpl() {
+        super(SafeZone.class);
+    }
+
+    @Override
+    public List<SafeZone> findAllByWardMemberKey(String wardMemberKey) {
+        return selectFrom(safeZone)
+                .where(safeZone.wardMemberKey.eq(wardMemberKey))
+                .orderBy(safeZone.createdAt.asc())
+                .fetch();
+    }
+
+    @Override
+    public Optional<SafeZone> findBySafeZoneKey(String safeZoneKey) {
+        return Optional.ofNullable(
+                selectFrom(safeZone)
+                        .where(safeZone.safeZoneKey.eq(safeZoneKey))
+                        .fetchOne()
+        );
+    }
+}

--- a/src/main/java/com/recaring/safezone/implement/SafeZoneReader.java
+++ b/src/main/java/com/recaring/safezone/implement/SafeZoneReader.java
@@ -1,0 +1,34 @@
+package com.recaring.safezone.implement;
+
+import com.recaring.safezone.dataaccess.entity.SafeZone;
+import com.recaring.safezone.dataaccess.repository.SafeZoneRepository;
+import com.recaring.safezone.vo.SafeZoneInfo;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class SafeZoneReader {
+
+    private final SafeZoneRepository safeZoneRepository;
+
+    public List<SafeZoneInfo> findAllByWardMemberKey(String wardMemberKey) {
+        return safeZoneRepository.findAllByWardMemberKey(wardMemberKey)
+                .stream()
+                .map(SafeZoneInfo::from)
+                .toList();
+    }
+
+    public SafeZoneInfo findBySafeZoneKey(String safeZoneKey) {
+        return SafeZoneInfo.from(getEntity(safeZoneKey));
+    }
+
+    public SafeZone getEntity(String safeZoneKey) {
+        return safeZoneRepository.findBySafeZoneKey(safeZoneKey)
+                .orElseThrow(() -> new AppException(ErrorType.NOT_FOUND_SAFE_ZONE));
+    }
+}

--- a/src/main/java/com/recaring/safezone/implement/SafeZoneWriter.java
+++ b/src/main/java/com/recaring/safezone/implement/SafeZoneWriter.java
@@ -1,0 +1,36 @@
+package com.recaring.safezone.implement;
+
+import com.recaring.safezone.controller.request.CreateSafeZoneCommand;
+import com.recaring.safezone.controller.request.UpdateSafeZoneCommand;
+import com.recaring.safezone.dataaccess.entity.SafeZone;
+import com.recaring.safezone.dataaccess.repository.SafeZoneRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SafeZoneWriter {
+
+    private final SafeZoneRepository safeZoneRepository;
+
+    public void register(CreateSafeZoneCommand command) {
+        safeZoneRepository.save(SafeZone.builder()
+                .wardMemberKey(command.wardMemberKey())
+                .name(command.name())
+                .address(command.address())
+                .latitude(command.latitude())
+                .longitude(command.longitude())
+                .radius(command.radius())
+                .build());
+    }
+
+    public void update(SafeZone zone, UpdateSafeZoneCommand command) {
+        zone.update(command.name(), command.address(), command.latitude(), command.longitude(), command.radius());
+        safeZoneRepository.save(zone);
+    }
+
+    public void delete(SafeZone zone) {
+        zone.delete();
+        safeZoneRepository.save(zone);
+    }
+}

--- a/src/main/java/com/recaring/safezone/vo/SafeZoneInfo.java
+++ b/src/main/java/com/recaring/safezone/vo/SafeZoneInfo.java
@@ -1,0 +1,24 @@
+package com.recaring.safezone.vo;
+
+import com.recaring.safezone.dataaccess.entity.SafeZone;
+import com.recaring.safezone.dataaccess.entity.SafeZoneRadius;
+
+public record SafeZoneInfo(
+        String safeZoneKey,
+        String name,
+        String address,
+        double latitude,
+        double longitude,
+        SafeZoneRadius radius
+) {
+    public static SafeZoneInfo from(SafeZone entity) {
+        return new SafeZoneInfo(
+                entity.getSafeZoneKey(),
+                entity.getName(),
+                entity.getAddress(),
+                entity.getLatitude(),
+                entity.getLongitude(),
+                entity.getRadius()
+        );
+    }
+}

--- a/src/main/java/com/recaring/support/exception/ErrorCode.java
+++ b/src/main/java/com/recaring/support/exception/ErrorCode.java
@@ -22,6 +22,9 @@ public enum ErrorCode {
     E6000, E6001, E6002,
 
     // Device (E7xxx) - Device Token
-    E7000
+    E7000,
+
+    // SafeZone (E8xxx) - 안심존
+    E8000, E8001
 
 }

--- a/src/main/java/com/recaring/support/exception/ErrorType.java
+++ b/src/main/java/com/recaring/support/exception/ErrorType.java
@@ -70,7 +70,11 @@ public enum ErrorType {
     INVALID_LOCATION_COLLECTION_INTERVAL(HttpStatus.BAD_REQUEST, ErrorCode.E6002, "지원하지 않는 위치 수집 주기입니다.", LogLevel.WARN),
 
     // Device (E7xxx)
-    INVALID_DEVICE_TOKEN(HttpStatus.UNAUTHORIZED, ErrorCode.E7000, "유효하지 않은 Device Token입니다.", LogLevel.WARN);
+    INVALID_DEVICE_TOKEN(HttpStatus.UNAUTHORIZED, ErrorCode.E7000, "유효하지 않은 Device Token입니다.", LogLevel.WARN),
+
+    // SafeZone (E8xxx)
+    NOT_FOUND_SAFE_ZONE(HttpStatus.BAD_REQUEST, ErrorCode.E8000, "존재하지 않는 안심존입니다.", LogLevel.WARN),
+    NOT_CAREGIVER_OF_WARD(HttpStatus.FORBIDDEN, ErrorCode.E8001, "해당 보호 대상자의 보호자/관계자가 아닙니다.", LogLevel.WARN);
 
     private final HttpStatus status;
     private final ErrorCode errorCode;

--- a/src/test/java/com/recaring/safezone/SafeZoneServiceTest.java
+++ b/src/test/java/com/recaring/safezone/SafeZoneServiceTest.java
@@ -1,5 +1,6 @@
 package com.recaring.safezone;
 
+import com.recaring.care.dataaccess.entity.CareRole;
 import com.recaring.care.dataaccess.repository.CareRelationshipRepository;
 import com.recaring.care.fixture.CareFixture;
 import com.recaring.safezone.business.SafeZoneService;
@@ -45,11 +46,11 @@ class SafeZoneServiceTest {
     // ── addSafeZone ──────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("케어 관계가 있는 보호자는 안심존을 추가한다")
-    void addSafeZone_success_when_caregiver() {
+    @DisplayName("CareRole.GUARDIAN인 보호자는 안심존을 추가한다")
+    void addSafeZone_success_when_guardian() {
         CreateSafeZoneCommand command = SafeZoneFixture.createCommand();
-        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
-                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(true);
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKeyAndCareRole(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY, CareRole.GUARDIAN)).willReturn(true);
 
         safeZoneService.addSafeZone(CareFixture.GUARDIAN_MEMBER_KEY, command);
 
@@ -57,15 +58,29 @@ class SafeZoneServiceTest {
     }
 
     @Test
-    @DisplayName("케어 관계가 없으면 안심존 추가 시 NOT_CAREGIVER_OF_WARD 예외가 발생한다")
-    void addSafeZone_throws_when_not_caregiver() {
+    @DisplayName("CareRole.MANAGER인 관계자가 안심존 추가 시 NOT_GUARDIAN_OF_WARD 예외가 발생한다")
+    void addSafeZone_throws_when_manager() {
         CreateSafeZoneCommand command = SafeZoneFixture.createCommand();
-        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
-                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(false);
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKeyAndCareRole(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.MANAGER_MEMBER_KEY, CareRole.GUARDIAN)).willReturn(false);
+
+        assertThatThrownBy(() -> safeZoneService.addSafeZone(CareFixture.MANAGER_MEMBER_KEY, command))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_GUARDIAN_OF_WARD);
+
+        then(safeZoneWriter).should(times(0)).register(any());
+    }
+
+    @Test
+    @DisplayName("케어 관계가 없으면 안심존 추가 시 NOT_GUARDIAN_OF_WARD 예외가 발생한다")
+    void addSafeZone_throws_when_not_guardian() {
+        CreateSafeZoneCommand command = SafeZoneFixture.createCommand();
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKeyAndCareRole(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY, CareRole.GUARDIAN)).willReturn(false);
 
         assertThatThrownBy(() -> safeZoneService.addSafeZone(CareFixture.GUARDIAN_MEMBER_KEY, command))
                 .isInstanceOf(AppException.class)
-                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_CAREGIVER_OF_WARD);
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_GUARDIAN_OF_WARD);
 
         then(safeZoneWriter).should(times(0)).register(any());
     }
@@ -73,8 +88,8 @@ class SafeZoneServiceTest {
     // ── getSafeZones ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("케어 관계가 있으면 안심존 목록을 반환한다")
-    void getSafeZones_returns_list_when_caregiver() {
+    @DisplayName("CareRole.GUARDIAN인 보호자는 안심존 목록을 조회한다")
+    void getSafeZones_returns_list_when_guardian() {
         SafeZone zone = SafeZoneFixture.createSafeZone();
         List<SafeZoneInfo> expected = List.of(SafeZoneFixture.createSafeZoneInfo(zone.getSafeZoneKey()));
         given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
@@ -82,6 +97,20 @@ class SafeZoneServiceTest {
         given(safeZoneReader.findAllByWardMemberKey(SafeZoneFixture.WARD_MEMBER_KEY)).willReturn(expected);
 
         List<SafeZoneInfo> result = safeZoneService.getSafeZones(CareFixture.GUARDIAN_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY);
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("CareRole.MANAGER인 관계자도 안심존 목록을 조회한다")
+    void getSafeZones_returns_list_when_manager() {
+        SafeZone zone = SafeZoneFixture.createSafeZone();
+        List<SafeZoneInfo> expected = List.of(SafeZoneFixture.createSafeZoneInfo(zone.getSafeZoneKey()));
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.MANAGER_MEMBER_KEY)).willReturn(true);
+        given(safeZoneReader.findAllByWardMemberKey(SafeZoneFixture.WARD_MEMBER_KEY)).willReturn(expected);
+
+        List<SafeZoneInfo> result = safeZoneService.getSafeZones(CareFixture.MANAGER_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY);
 
         assertThat(result).isEqualTo(expected);
     }
@@ -102,8 +131,8 @@ class SafeZoneServiceTest {
     // ── getSafeZone ──────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("케어 관계가 있으면 안심존 상세를 반환한다")
-    void getSafeZone_returns_info_when_caregiver() {
+    @DisplayName("CareRole.GUARDIAN인 보호자는 안심존 상세를 조회한다")
+    void getSafeZone_returns_info_when_guardian() {
         SafeZone zone = SafeZoneFixture.createSafeZone();
         SafeZoneInfo expected = SafeZoneFixture.createSafeZoneInfo(zone.getSafeZoneKey());
         given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
@@ -116,15 +145,30 @@ class SafeZoneServiceTest {
         assertThat(result).isEqualTo(expected);
     }
 
+    @Test
+    @DisplayName("CareRole.MANAGER인 관계자도 안심존 상세를 조회한다")
+    void getSafeZone_returns_info_when_manager() {
+        SafeZone zone = SafeZoneFixture.createSafeZone();
+        SafeZoneInfo expected = SafeZoneFixture.createSafeZoneInfo(zone.getSafeZoneKey());
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.MANAGER_MEMBER_KEY)).willReturn(true);
+        given(safeZoneReader.findBySafeZoneKey(zone.getSafeZoneKey())).willReturn(expected);
+
+        SafeZoneInfo result = safeZoneService.getSafeZone(
+                CareFixture.MANAGER_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY, zone.getSafeZoneKey());
+
+        assertThat(result).isEqualTo(expected);
+    }
+
     // ── updateSafeZone ───────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("케어 관계가 있으면 안심존을 수정한다")
-    void updateSafeZone_success_when_caregiver() {
+    @DisplayName("CareRole.GUARDIAN인 보호자는 안심존을 수정한다")
+    void updateSafeZone_success_when_guardian() {
         SafeZone zone = SafeZoneFixture.createSafeZone();
         UpdateSafeZoneCommand command = SafeZoneFixture.updateCommand();
-        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
-                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(true);
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKeyAndCareRole(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY, CareRole.GUARDIAN)).willReturn(true);
         given(safeZoneReader.getEntity(zone.getSafeZoneKey())).willReturn(zone);
 
         safeZoneService.updateSafeZone(CareFixture.GUARDIAN_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY, zone.getSafeZoneKey(), command);
@@ -133,16 +177,31 @@ class SafeZoneServiceTest {
     }
 
     @Test
-    @DisplayName("케어 관계가 없으면 수정 시 NOT_CAREGIVER_OF_WARD 예외가 발생한다")
-    void updateSafeZone_throws_when_not_caregiver() {
+    @DisplayName("CareRole.MANAGER인 관계자가 안심존 수정 시 NOT_GUARDIAN_OF_WARD 예외가 발생한다")
+    void updateSafeZone_throws_when_manager() {
         UpdateSafeZoneCommand command = SafeZoneFixture.updateCommand();
-        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
-                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(false);
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKeyAndCareRole(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.MANAGER_MEMBER_KEY, CareRole.GUARDIAN)).willReturn(false);
+
+        assertThatThrownBy(() -> safeZoneService.updateSafeZone(
+                CareFixture.MANAGER_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY, "any-key", command))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_GUARDIAN_OF_WARD);
+
+        then(safeZoneWriter).should(times(0)).update(any(), any());
+    }
+
+    @Test
+    @DisplayName("케어 관계가 없으면 수정 시 NOT_GUARDIAN_OF_WARD 예외가 발생한다")
+    void updateSafeZone_throws_when_not_guardian() {
+        UpdateSafeZoneCommand command = SafeZoneFixture.updateCommand();
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKeyAndCareRole(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY, CareRole.GUARDIAN)).willReturn(false);
 
         assertThatThrownBy(() -> safeZoneService.updateSafeZone(
                 CareFixture.GUARDIAN_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY, "any-key", command))
                 .isInstanceOf(AppException.class)
-                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_CAREGIVER_OF_WARD);
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_GUARDIAN_OF_WARD);
 
         then(safeZoneWriter).should(times(0)).update(any(), any());
     }
@@ -150,11 +209,11 @@ class SafeZoneServiceTest {
     // ── deleteSafeZone ───────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("케어 관계가 있으면 안심존을 삭제한다")
-    void deleteSafeZone_success_when_caregiver() {
+    @DisplayName("CareRole.GUARDIAN인 보호자는 안심존을 삭제한다")
+    void deleteSafeZone_success_when_guardian() {
         SafeZone zone = SafeZoneFixture.createSafeZone();
-        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
-                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(true);
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKeyAndCareRole(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY, CareRole.GUARDIAN)).willReturn(true);
         given(safeZoneReader.getEntity(zone.getSafeZoneKey())).willReturn(zone);
 
         safeZoneService.deleteSafeZone(CareFixture.GUARDIAN_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY, zone.getSafeZoneKey());
@@ -163,15 +222,29 @@ class SafeZoneServiceTest {
     }
 
     @Test
-    @DisplayName("케어 관계가 없으면 삭제 시 NOT_CAREGIVER_OF_WARD 예외가 발생한다")
-    void deleteSafeZone_throws_when_not_caregiver() {
-        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
-                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(false);
+    @DisplayName("CareRole.MANAGER인 관계자가 안심존 삭제 시 NOT_GUARDIAN_OF_WARD 예외가 발생한다")
+    void deleteSafeZone_throws_when_manager() {
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKeyAndCareRole(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.MANAGER_MEMBER_KEY, CareRole.GUARDIAN)).willReturn(false);
+
+        assertThatThrownBy(() -> safeZoneService.deleteSafeZone(
+                CareFixture.MANAGER_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY, "any-key"))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_GUARDIAN_OF_WARD);
+
+        then(safeZoneWriter).should(times(0)).delete(any());
+    }
+
+    @Test
+    @DisplayName("케어 관계가 없으면 삭제 시 NOT_GUARDIAN_OF_WARD 예외가 발생한다")
+    void deleteSafeZone_throws_when_not_guardian() {
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKeyAndCareRole(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY, CareRole.GUARDIAN)).willReturn(false);
 
         assertThatThrownBy(() -> safeZoneService.deleteSafeZone(
                 CareFixture.GUARDIAN_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY, "any-key"))
                 .isInstanceOf(AppException.class)
-                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_CAREGIVER_OF_WARD);
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_GUARDIAN_OF_WARD);
 
         then(safeZoneWriter).should(times(0)).delete(any());
     }

--- a/src/test/java/com/recaring/safezone/SafeZoneServiceTest.java
+++ b/src/test/java/com/recaring/safezone/SafeZoneServiceTest.java
@@ -1,0 +1,178 @@
+package com.recaring.safezone;
+
+import com.recaring.care.dataaccess.repository.CareRelationshipRepository;
+import com.recaring.care.fixture.CareFixture;
+import com.recaring.safezone.business.SafeZoneService;
+import com.recaring.safezone.controller.request.CreateSafeZoneCommand;
+import com.recaring.safezone.controller.request.UpdateSafeZoneCommand;
+import com.recaring.safezone.dataaccess.entity.SafeZone;
+import com.recaring.safezone.fixture.SafeZoneFixture;
+import com.recaring.safezone.implement.SafeZoneReader;
+import com.recaring.safezone.implement.SafeZoneWriter;
+import com.recaring.safezone.vo.SafeZoneInfo;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SafeZoneService 단위 테스트")
+class SafeZoneServiceTest {
+
+    @InjectMocks
+    private SafeZoneService safeZoneService;
+
+    @Mock
+    private SafeZoneReader safeZoneReader;
+
+    @Mock
+    private SafeZoneWriter safeZoneWriter;
+
+    @Mock
+    private CareRelationshipRepository careRelationshipRepository;
+
+    // ── addSafeZone ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("케어 관계가 있는 보호자는 안심존을 추가한다")
+    void addSafeZone_success_when_caregiver() {
+        CreateSafeZoneCommand command = SafeZoneFixture.createCommand();
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(true);
+
+        safeZoneService.addSafeZone(CareFixture.GUARDIAN_MEMBER_KEY, command);
+
+        then(safeZoneWriter).should(times(1)).register(command);
+    }
+
+    @Test
+    @DisplayName("케어 관계가 없으면 안심존 추가 시 NOT_CAREGIVER_OF_WARD 예외가 발생한다")
+    void addSafeZone_throws_when_not_caregiver() {
+        CreateSafeZoneCommand command = SafeZoneFixture.createCommand();
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(false);
+
+        assertThatThrownBy(() -> safeZoneService.addSafeZone(CareFixture.GUARDIAN_MEMBER_KEY, command))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_CAREGIVER_OF_WARD);
+
+        then(safeZoneWriter).should(times(0)).register(any());
+    }
+
+    // ── getSafeZones ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("케어 관계가 있으면 안심존 목록을 반환한다")
+    void getSafeZones_returns_list_when_caregiver() {
+        SafeZone zone = SafeZoneFixture.createSafeZone();
+        List<SafeZoneInfo> expected = List.of(SafeZoneFixture.createSafeZoneInfo(zone.getSafeZoneKey()));
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(true);
+        given(safeZoneReader.findAllByWardMemberKey(SafeZoneFixture.WARD_MEMBER_KEY)).willReturn(expected);
+
+        List<SafeZoneInfo> result = safeZoneService.getSafeZones(CareFixture.GUARDIAN_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY);
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("케어 관계가 없으면 목록 조회 시 NOT_CAREGIVER_OF_WARD 예외가 발생한다")
+    void getSafeZones_throws_when_not_caregiver() {
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(false);
+
+        assertThatThrownBy(() -> safeZoneService.getSafeZones(CareFixture.GUARDIAN_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_CAREGIVER_OF_WARD);
+
+        then(safeZoneReader).should(times(0)).findAllByWardMemberKey(any());
+    }
+
+    // ── getSafeZone ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("케어 관계가 있으면 안심존 상세를 반환한다")
+    void getSafeZone_returns_info_when_caregiver() {
+        SafeZone zone = SafeZoneFixture.createSafeZone();
+        SafeZoneInfo expected = SafeZoneFixture.createSafeZoneInfo(zone.getSafeZoneKey());
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(true);
+        given(safeZoneReader.findBySafeZoneKey(zone.getSafeZoneKey())).willReturn(expected);
+
+        SafeZoneInfo result = safeZoneService.getSafeZone(
+                CareFixture.GUARDIAN_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY, zone.getSafeZoneKey());
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    // ── updateSafeZone ───────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("케어 관계가 있으면 안심존을 수정한다")
+    void updateSafeZone_success_when_caregiver() {
+        SafeZone zone = SafeZoneFixture.createSafeZone();
+        UpdateSafeZoneCommand command = SafeZoneFixture.updateCommand();
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(true);
+        given(safeZoneReader.getEntity(zone.getSafeZoneKey())).willReturn(zone);
+
+        safeZoneService.updateSafeZone(CareFixture.GUARDIAN_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY, zone.getSafeZoneKey(), command);
+
+        then(safeZoneWriter).should(times(1)).update(zone, command);
+    }
+
+    @Test
+    @DisplayName("케어 관계가 없으면 수정 시 NOT_CAREGIVER_OF_WARD 예외가 발생한다")
+    void updateSafeZone_throws_when_not_caregiver() {
+        UpdateSafeZoneCommand command = SafeZoneFixture.updateCommand();
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(false);
+
+        assertThatThrownBy(() -> safeZoneService.updateSafeZone(
+                CareFixture.GUARDIAN_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY, "any-key", command))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_CAREGIVER_OF_WARD);
+
+        then(safeZoneWriter).should(times(0)).update(any(), any());
+    }
+
+    // ── deleteSafeZone ───────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("케어 관계가 있으면 안심존을 삭제한다")
+    void deleteSafeZone_success_when_caregiver() {
+        SafeZone zone = SafeZoneFixture.createSafeZone();
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(true);
+        given(safeZoneReader.getEntity(zone.getSafeZoneKey())).willReturn(zone);
+
+        safeZoneService.deleteSafeZone(CareFixture.GUARDIAN_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY, zone.getSafeZoneKey());
+
+        then(safeZoneWriter).should(times(1)).delete(zone);
+    }
+
+    @Test
+    @DisplayName("케어 관계가 없으면 삭제 시 NOT_CAREGIVER_OF_WARD 예외가 발생한다")
+    void deleteSafeZone_throws_when_not_caregiver() {
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
+                SafeZoneFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY)).willReturn(false);
+
+        assertThatThrownBy(() -> safeZoneService.deleteSafeZone(
+                CareFixture.GUARDIAN_MEMBER_KEY, SafeZoneFixture.WARD_MEMBER_KEY, "any-key"))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_CAREGIVER_OF_WARD);
+
+        then(safeZoneWriter).should(times(0)).delete(any());
+    }
+}

--- a/src/test/java/com/recaring/safezone/controller/SafeZoneControllerTest.java
+++ b/src/test/java/com/recaring/safezone/controller/SafeZoneControllerTest.java
@@ -30,22 +30,30 @@ class SafeZoneControllerTest extends AbstractIntegrationTest {
     @Autowired private PasswordEncoder passwordEncoder;
 
     private Member guardian;
+    private Member manager;
     private Member ward;
     private String guardianToken;
+    private String managerToken;
     private CareRelationship relationship;
     private SafeZone savedZone;
 
     @BeforeEach
     void setUp() {
         guardian = memberRepository.save(CareFixture.createGuardianMember());
+        manager = memberRepository.save(CareFixture.createGuardianMember(CareFixture.MANAGER_PHONE));
         ward = memberRepository.save(CareFixture.createWardMember());
 
         String encoded = passwordEncoder.encode("Password1");
         localAuthRepository.save(LocalAuth.of(guardian.getMemberKey(), "guardian@test.com", encoded));
+        localAuthRepository.save(LocalAuth.of(manager.getMemberKey(), "manager@test.com", encoded));
 
         guardianToken = extractAccessToken("guardian@test.com", "Password1");
+        managerToken = extractAccessToken("manager@test.com", "Password1");
+
         relationship = careRelationshipRepository.save(
                 CareFixture.createGuardianRelationship(ward.getMemberKey(), guardian.getMemberKey()));
+        careRelationshipRepository.save(
+                CareFixture.createManagerRelationship(ward.getMemberKey(), manager.getMemberKey()));
         savedZone = safeZoneRepository.save(SafeZoneFixture.createSafeZone(ward.getMemberKey()));
     }
 
@@ -99,6 +107,20 @@ class SafeZoneControllerTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @DisplayName("POST - 관계자가 안심존 추가 시 403이 반환된다")
+    void addSafeZone_returns_403_when_manager() {
+        client.post()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + managerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {"name": "학교", "address": "서울시", "latitude": 37.5, "longitude": 127.0, "radius": "SMALL"}
+                        """)
+                .exchange()
+                .expectStatus().isForbidden();
+    }
+
+    @Test
     @DisplayName("POST - 인증 없이 요청하면 401이 반환된다")
     void addSafeZone_without_auth_returns_401() {
         client.post()
@@ -134,7 +156,7 @@ class SafeZoneControllerTest extends AbstractIntegrationTest {
 
     @Test
     @DisplayName("GET 목록 - 보호자가 조회하면 안심존 목록이 반환된다")
-    void getSafeZones_returns_list() {
+    void getSafeZones_returns_list_when_guardian() {
         client.get()
                 .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones")
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + guardianToken)
@@ -145,6 +167,20 @@ class SafeZoneControllerTest extends AbstractIntegrationTest {
                 .jsonPath("$.data").isArray()
                 .jsonPath("$.data[0].name").isEqualTo(SafeZoneFixture.NAME)
                 .jsonPath("$.data[0].safeZoneKey").isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("GET 목록 - 관계자가 조회하면 안심존 목록이 반환된다")
+    void getSafeZones_returns_list_when_manager() {
+        client.get()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + managerToken)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("SUCCESS")
+                .jsonPath("$.data").isArray()
+                .jsonPath("$.data[0].name").isEqualTo(SafeZoneFixture.NAME);
     }
 
     @Test
@@ -160,7 +196,7 @@ class SafeZoneControllerTest extends AbstractIntegrationTest {
 
     @Test
     @DisplayName("GET 상세 - 보호자가 조회하면 안심존 상세가 반환된다")
-    void getSafeZone_returns_detail() {
+    void getSafeZone_returns_detail_when_guardian() {
         client.get()
                 .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones/" + savedZone.getSafeZoneKey())
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + guardianToken)
@@ -171,6 +207,19 @@ class SafeZoneControllerTest extends AbstractIntegrationTest {
                 .jsonPath("$.data.name").isEqualTo(SafeZoneFixture.NAME)
                 .jsonPath("$.data.address").isEqualTo(SafeZoneFixture.ADDRESS)
                 .jsonPath("$.data.radiusMeters").isEqualTo(SafeZoneFixture.RADIUS.getMeters());
+    }
+
+    @Test
+    @DisplayName("GET 상세 - 관계자가 조회하면 안심존 상세가 반환된다")
+    void getSafeZone_returns_detail_when_manager() {
+        client.get()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones/" + savedZone.getSafeZoneKey())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + managerToken)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("SUCCESS")
+                .jsonPath("$.data.name").isEqualTo(SafeZoneFixture.NAME);
     }
 
     @Test
@@ -208,6 +257,20 @@ class SafeZoneControllerTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @DisplayName("PATCH - 관계자가 안심존 수정 시 403이 반환된다")
+    void updateSafeZone_returns_403_when_manager() {
+        client.patch()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones/" + savedZone.getSafeZoneKey())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + managerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {"name": "직장", "address": "서울시", "latitude": 37.5, "longitude": 127.0, "radius": "LARGE"}
+                        """)
+                .exchange()
+                .expectStatus().isForbidden();
+    }
+
+    @Test
     @DisplayName("PATCH - 케어 관계가 없는 보호자가 수정하면 403이 반환된다")
     void updateSafeZone_returns_403_when_not_caregiver() {
         Member stranger = memberRepository.save(CareFixture.createGuardianMember("01088889999"));
@@ -238,6 +301,16 @@ class SafeZoneControllerTest extends AbstractIntegrationTest {
                 .expectStatus().isOk()
                 .expectBody()
                 .jsonPath("$.resultType").isEqualTo("SUCCESS");
+    }
+
+    @Test
+    @DisplayName("DELETE - 관계자가 안심존 삭제 시 403이 반환된다")
+    void deleteSafeZone_returns_403_when_manager() {
+        client.delete()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones/" + savedZone.getSafeZoneKey())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + managerToken)
+                .exchange()
+                .expectStatus().isForbidden();
     }
 
     @Test

--- a/src/test/java/com/recaring/safezone/controller/SafeZoneControllerTest.java
+++ b/src/test/java/com/recaring/safezone/controller/SafeZoneControllerTest.java
@@ -1,0 +1,257 @@
+package com.recaring.safezone.controller;
+
+import com.recaring.auth.dataaccess.entity.LocalAuth;
+import com.recaring.auth.dataaccess.repository.LocalAuthRepository;
+import com.recaring.care.dataaccess.entity.CareRelationship;
+import com.recaring.care.dataaccess.repository.CareRelationshipRepository;
+import com.recaring.care.fixture.CareFixture;
+import com.recaring.member.dataaccess.entity.Member;
+import com.recaring.member.dataaccess.repository.MemberRepository;
+import com.recaring.safezone.dataaccess.entity.SafeZone;
+import com.recaring.safezone.dataaccess.repository.SafeZoneRepository;
+import com.recaring.safezone.fixture.SafeZoneFixture;
+import com.recaring.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@DisplayName("SafeZoneController HTTP 통합 테스트")
+class SafeZoneControllerTest extends AbstractIntegrationTest {
+
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private LocalAuthRepository localAuthRepository;
+    @Autowired private CareRelationshipRepository careRelationshipRepository;
+    @Autowired private SafeZoneRepository safeZoneRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+
+    private Member guardian;
+    private Member ward;
+    private String guardianToken;
+    private CareRelationship relationship;
+    private SafeZone savedZone;
+
+    @BeforeEach
+    void setUp() {
+        guardian = memberRepository.save(CareFixture.createGuardianMember());
+        ward = memberRepository.save(CareFixture.createWardMember());
+
+        String encoded = passwordEncoder.encode("Password1");
+        localAuthRepository.save(LocalAuth.of(guardian.getMemberKey(), "guardian@test.com", encoded));
+
+        guardianToken = extractAccessToken("guardian@test.com", "Password1");
+        relationship = careRelationshipRepository.save(
+                CareFixture.createGuardianRelationship(ward.getMemberKey(), guardian.getMemberKey()));
+        savedZone = safeZoneRepository.save(SafeZoneFixture.createSafeZone(ward.getMemberKey()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        safeZoneRepository.deleteAllInBatch();
+        careRelationshipRepository.deleteAllInBatch();
+        localAuthRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    private String extractAccessToken(String email, String password) {
+        var result = client.post()
+                .uri("/api/v1/auth/sign-in/local")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {"email": "%s", "password": "%s"}
+                        """.formatted(email, password))
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .returnResult();
+        String body = new String(result.getResponseBody());
+        int start = body.indexOf("\"accessToken\":\"") + 15;
+        int end = body.indexOf("\"", start);
+        return body.substring(start, end);
+    }
+
+    // ── POST /api/v1/care/wards/{wardKey}/safe-zones ─────────────────────────
+
+    @Test
+    @DisplayName("POST - 보호자가 안심존을 추가하면 201이 반환된다")
+    void addSafeZone_success() {
+        client.post()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + guardianToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {
+                          "name": "학교",
+                          "address": "서울시 마포구 1",
+                          "latitude": 37.55,
+                          "longitude": 126.92,
+                          "radius": "SMALL"
+                        }
+                        """)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("SUCCESS");
+    }
+
+    @Test
+    @DisplayName("POST - 인증 없이 요청하면 401이 반환된다")
+    void addSafeZone_without_auth_returns_401() {
+        client.post()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {"name": "학교", "address": "서울시", "latitude": 37.5, "longitude": 127.0, "radius": "SMALL"}
+                        """)
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("POST - 케어 관계가 없는 보호자가 요청하면 403이 반환된다")
+    void addSafeZone_returns_403_when_not_caregiver() {
+        Member stranger = memberRepository.save(CareFixture.createGuardianMember("01077778888"));
+        localAuthRepository.save(LocalAuth.of(stranger.getMemberKey(), "stranger@test.com",
+                passwordEncoder.encode("Password1")));
+        String strangerToken = extractAccessToken("stranger@test.com", "Password1");
+
+        client.post()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + strangerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {"name": "학교", "address": "서울시", "latitude": 37.5, "longitude": 127.0, "radius": "SMALL"}
+                        """)
+                .exchange()
+                .expectStatus().isForbidden();
+    }
+
+    // ── GET /api/v1/care/wards/{wardKey}/safe-zones ──────────────────────────
+
+    @Test
+    @DisplayName("GET 목록 - 보호자가 조회하면 안심존 목록이 반환된다")
+    void getSafeZones_returns_list() {
+        client.get()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + guardianToken)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("SUCCESS")
+                .jsonPath("$.data").isArray()
+                .jsonPath("$.data[0].name").isEqualTo(SafeZoneFixture.NAME)
+                .jsonPath("$.data[0].safeZoneKey").isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("GET 목록 - 인증 없이 요청하면 401이 반환된다")
+    void getSafeZones_without_auth_returns_401() {
+        client.get()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones")
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    // ── GET /api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey} ────────────
+
+    @Test
+    @DisplayName("GET 상세 - 보호자가 조회하면 안심존 상세가 반환된다")
+    void getSafeZone_returns_detail() {
+        client.get()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones/" + savedZone.getSafeZoneKey())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + guardianToken)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("SUCCESS")
+                .jsonPath("$.data.name").isEqualTo(SafeZoneFixture.NAME)
+                .jsonPath("$.data.address").isEqualTo(SafeZoneFixture.ADDRESS)
+                .jsonPath("$.data.radiusMeters").isEqualTo(SafeZoneFixture.RADIUS.getMeters());
+    }
+
+    @Test
+    @DisplayName("GET 상세 - 존재하지 않는 key를 요청하면 4xx가 반환된다")
+    void getSafeZone_returns_4xx_when_not_found() {
+        client.get()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones/non-existent-key")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + guardianToken)
+                .exchange()
+                .expectStatus().is4xxClientError();
+    }
+
+    // ── PATCH /api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey} ──────────
+
+    @Test
+    @DisplayName("PATCH - 보호자가 안심존을 수정하면 200이 반환된다")
+    void updateSafeZone_success() {
+        client.patch()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones/" + savedZone.getSafeZoneKey())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + guardianToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {
+                          "name": "직장",
+                          "address": "서울시 서초구 반포대로 2",
+                          "latitude": 37.49,
+                          "longitude": 127.01,
+                          "radius": "LARGE"
+                        }
+                        """)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("SUCCESS");
+    }
+
+    @Test
+    @DisplayName("PATCH - 케어 관계가 없는 보호자가 수정하면 403이 반환된다")
+    void updateSafeZone_returns_403_when_not_caregiver() {
+        Member stranger = memberRepository.save(CareFixture.createGuardianMember("01088889999"));
+        localAuthRepository.save(LocalAuth.of(stranger.getMemberKey(), "stranger2@test.com",
+                passwordEncoder.encode("Password1")));
+        String strangerToken = extractAccessToken("stranger2@test.com", "Password1");
+
+        client.patch()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones/" + savedZone.getSafeZoneKey())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + strangerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {"name": "직장", "address": "서울시", "latitude": 37.5, "longitude": 127.0, "radius": "LARGE"}
+                        """)
+                .exchange()
+                .expectStatus().isForbidden();
+    }
+
+    // ── DELETE /api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey} ─────────
+
+    @Test
+    @DisplayName("DELETE - 보호자가 안심존을 삭제하면 200이 반환된다")
+    void deleteSafeZone_success() {
+        client.delete()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones/" + savedZone.getSafeZoneKey())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + guardianToken)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("SUCCESS");
+    }
+
+    @Test
+    @DisplayName("DELETE - 케어 관계가 없는 보호자가 삭제하면 403이 반환된다")
+    void deleteSafeZone_returns_403_when_not_caregiver() {
+        Member stranger = memberRepository.save(CareFixture.createGuardianMember("01011110000"));
+        localAuthRepository.save(LocalAuth.of(stranger.getMemberKey(), "stranger3@test.com",
+                passwordEncoder.encode("Password1")));
+        String strangerToken = extractAccessToken("stranger3@test.com", "Password1");
+
+        client.delete()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/safe-zones/" + savedZone.getSafeZoneKey())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + strangerToken)
+                .exchange()
+                .expectStatus().isForbidden();
+    }
+}

--- a/src/test/java/com/recaring/safezone/fixture/SafeZoneFixture.java
+++ b/src/test/java/com/recaring/safezone/fixture/SafeZoneFixture.java
@@ -1,0 +1,58 @@
+package com.recaring.safezone.fixture;
+
+import com.recaring.care.fixture.CareFixture;
+import com.recaring.safezone.controller.request.CreateSafeZoneCommand;
+import com.recaring.safezone.controller.request.UpdateSafeZoneCommand;
+import com.recaring.safezone.dataaccess.entity.SafeZone;
+import com.recaring.safezone.dataaccess.entity.SafeZoneRadius;
+import com.recaring.safezone.vo.SafeZoneInfo;
+
+public class SafeZoneFixture {
+
+    public static final String WARD_MEMBER_KEY = CareFixture.WARD_MEMBER_KEY;
+    public static final String NAME = "우리집";
+    public static final String ADDRESS = "서울시 강남구 테헤란로 1";
+    public static final double LATITUDE = 37.5000;
+    public static final double LONGITUDE = 127.0000;
+    public static final SafeZoneRadius RADIUS = SafeZoneRadius.MEDIUM;
+
+    public static final String UPDATED_NAME = "직장";
+    public static final String UPDATED_ADDRESS = "서울시 서초구 반포대로 2";
+    public static final double UPDATED_LATITUDE = 37.4900;
+    public static final double UPDATED_LONGITUDE = 127.0100;
+    public static final SafeZoneRadius UPDATED_RADIUS = SafeZoneRadius.LARGE;
+
+    public static SafeZone createSafeZone() {
+        return SafeZone.builder()
+                .wardMemberKey(WARD_MEMBER_KEY)
+                .name(NAME)
+                .address(ADDRESS)
+                .latitude(LATITUDE)
+                .longitude(LONGITUDE)
+                .radius(RADIUS)
+                .build();
+    }
+
+    public static SafeZone createSafeZone(String wardMemberKey) {
+        return SafeZone.builder()
+                .wardMemberKey(wardMemberKey)
+                .name(NAME)
+                .address(ADDRESS)
+                .latitude(LATITUDE)
+                .longitude(LONGITUDE)
+                .radius(RADIUS)
+                .build();
+    }
+
+    public static SafeZoneInfo createSafeZoneInfo(String safeZoneKey) {
+        return new SafeZoneInfo(safeZoneKey, NAME, ADDRESS, LATITUDE, LONGITUDE, RADIUS);
+    }
+
+    public static CreateSafeZoneCommand createCommand() {
+        return new CreateSafeZoneCommand(WARD_MEMBER_KEY, NAME, ADDRESS, LATITUDE, LONGITUDE, RADIUS);
+    }
+
+    public static UpdateSafeZoneCommand updateCommand() {
+        return new UpdateSafeZoneCommand(UPDATED_NAME, UPDATED_ADDRESS, UPDATED_LATITUDE, UPDATED_LONGITUDE, UPDATED_RADIUS);
+    }
+}

--- a/src/test/java/com/recaring/safezone/implement/SafeZoneReaderTest.java
+++ b/src/test/java/com/recaring/safezone/implement/SafeZoneReaderTest.java
@@ -1,0 +1,94 @@
+package com.recaring.safezone.implement;
+
+import com.recaring.safezone.dataaccess.entity.SafeZone;
+import com.recaring.safezone.dataaccess.repository.SafeZoneRepository;
+import com.recaring.safezone.fixture.SafeZoneFixture;
+import com.recaring.safezone.vo.SafeZoneInfo;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SafeZoneReader 단위 테스트")
+class SafeZoneReaderTest {
+
+    @InjectMocks
+    private SafeZoneReader safeZoneReader;
+
+    @Mock
+    private SafeZoneRepository safeZoneRepository;
+
+    @Test
+    @DisplayName("wardMemberKey로 안심존 목록을 VO로 변환해 반환한다")
+    void findAllByWardMemberKey_returns_mapped_list() {
+        SafeZone zone = SafeZoneFixture.createSafeZone();
+        given(safeZoneRepository.findAllByWardMemberKey(SafeZoneFixture.WARD_MEMBER_KEY))
+                .willReturn(List.of(zone));
+
+        List<SafeZoneInfo> result = safeZoneReader.findAllByWardMemberKey(SafeZoneFixture.WARD_MEMBER_KEY);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name()).isEqualTo(SafeZoneFixture.NAME);
+        assertThat(result.get(0).radius()).isEqualTo(SafeZoneFixture.RADIUS);
+        then(safeZoneRepository).should(times(1)).findAllByWardMemberKey(SafeZoneFixture.WARD_MEMBER_KEY);
+    }
+
+    @Test
+    @DisplayName("safeZoneKey로 안심존 VO를 반환한다")
+    void findBySafeZoneKey_returns_info() {
+        SafeZone zone = SafeZoneFixture.createSafeZone();
+        given(safeZoneRepository.findBySafeZoneKey(zone.getSafeZoneKey()))
+                .willReturn(Optional.of(zone));
+
+        SafeZoneInfo result = safeZoneReader.findBySafeZoneKey(zone.getSafeZoneKey());
+
+        assertThat(result.name()).isEqualTo(SafeZoneFixture.NAME);
+        assertThat(result.address()).isEqualTo(SafeZoneFixture.ADDRESS);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 safeZoneKey 조회 시 NOT_FOUND_SAFE_ZONE 예외가 발생한다")
+    void findBySafeZoneKey_throws_when_not_found() {
+        given(safeZoneRepository.findBySafeZoneKey("unknown-key")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> safeZoneReader.findBySafeZoneKey("unknown-key"))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_FOUND_SAFE_ZONE);
+    }
+
+    @Test
+    @DisplayName("getEntity는 수정/삭제용 엔티티를 반환한다")
+    void getEntity_returns_entity() {
+        SafeZone zone = SafeZoneFixture.createSafeZone();
+        given(safeZoneRepository.findBySafeZoneKey(zone.getSafeZoneKey()))
+                .willReturn(Optional.of(zone));
+
+        SafeZone result = safeZoneReader.getEntity(zone.getSafeZoneKey());
+
+        assertThat(result).isEqualTo(zone);
+    }
+
+    @Test
+    @DisplayName("getEntity 조회 시 존재하지 않으면 NOT_FOUND_SAFE_ZONE 예외가 발생한다")
+    void getEntity_throws_when_not_found() {
+        given(safeZoneRepository.findBySafeZoneKey("unknown-key")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> safeZoneReader.getEntity("unknown-key"))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_FOUND_SAFE_ZONE);
+    }
+}

--- a/src/test/java/com/recaring/safezone/implement/SafeZoneWriterTest.java
+++ b/src/test/java/com/recaring/safezone/implement/SafeZoneWriterTest.java
@@ -1,0 +1,72 @@
+package com.recaring.safezone.implement;
+
+import com.recaring.safezone.controller.request.CreateSafeZoneCommand;
+import com.recaring.safezone.controller.request.UpdateSafeZoneCommand;
+import com.recaring.safezone.dataaccess.entity.SafeZone;
+import com.recaring.safezone.dataaccess.repository.SafeZoneRepository;
+import com.recaring.safezone.fixture.SafeZoneFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SafeZoneWriter 단위 테스트")
+class SafeZoneWriterTest {
+
+    @InjectMocks
+    private SafeZoneWriter safeZoneWriter;
+
+    @Mock
+    private SafeZoneRepository safeZoneRepository;
+
+    @Test
+    @DisplayName("register 호출 시 올바른 필드로 안심존 엔티티를 저장한다")
+    void register_saves_entity_with_correct_fields() {
+        CreateSafeZoneCommand command = SafeZoneFixture.createCommand();
+        ArgumentCaptor<SafeZone> captor = ArgumentCaptor.forClass(SafeZone.class);
+
+        safeZoneWriter.register(command);
+
+        then(safeZoneRepository).should(times(1)).save(captor.capture());
+        SafeZone saved = captor.getValue();
+        assertThat(saved.getWardMemberKey()).isEqualTo(SafeZoneFixture.WARD_MEMBER_KEY);
+        assertThat(saved.getName()).isEqualTo(SafeZoneFixture.NAME);
+        assertThat(saved.getAddress()).isEqualTo(SafeZoneFixture.ADDRESS);
+        assertThat(saved.getRadius()).isEqualTo(SafeZoneFixture.RADIUS);
+        assertThat(saved.getSafeZoneKey()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("update 호출 시 엔티티 필드가 command 값으로 변경되고 저장된다")
+    void update_mutates_entity_and_saves() {
+        SafeZone zone = SafeZoneFixture.createSafeZone();
+        UpdateSafeZoneCommand command = SafeZoneFixture.updateCommand();
+
+        safeZoneWriter.update(zone, command);
+
+        assertThat(zone.getName()).isEqualTo(SafeZoneFixture.UPDATED_NAME);
+        assertThat(zone.getAddress()).isEqualTo(SafeZoneFixture.UPDATED_ADDRESS);
+        assertThat(zone.getRadius()).isEqualTo(SafeZoneFixture.UPDATED_RADIUS);
+        then(safeZoneRepository).should(times(1)).save(zone);
+    }
+
+    @Test
+    @DisplayName("delete 호출 시 deletedAt이 설정되고 저장된다")
+    void delete_marks_deleted_and_saves() {
+        SafeZone zone = SafeZoneFixture.createSafeZone();
+
+        safeZoneWriter.delete(zone);
+
+        assertThat(zone.isDeleted()).isTrue();
+        then(safeZoneRepository).should(times(1)).save(zone);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
> feature [#82]

## 요약
> 안심존 API를 구현하고, 역할별 접근 권한을 수정했습니다.

## 변경사항(상세)
> 
안심존 API 구현 (feat: implement safety zone API)
  - 안심존 추가 / 목록 조회 / 상세 조회 / 수정 / 삭제 엔드포인트 구현
  - POST /api/v1/care/wards/{wardKey}/safe-zones
  - GET /api/v1/care/wards/{wardKey}/safe-zones
  - GET /api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}
  - PATCH /api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}
  - DELETE /api/v1/care/wards/{wardKey}/safe-zones/{safeZoneKey}

  테스트 코드 작성 (test: add safety zone API tests)
  - SafeZoneServiceTest — 서비스 단위 테스트
  - SafeZoneControllerTest — HTTP 통합 테스트
  - SafeZoneReaderTest, SafeZoneWriterTest, SafeZoneFixture 추가

  안심존 역할 권한 수정 (fix: restrict safe-zone write operations to GUARDIAN role only)
  - 추가·수정·삭제: CareRole.GUARDIAN(보호자)만 가능
  - 목록·상세 조회: CareRole.GUARDIAN + CareRole.MANAGER(관계자) 모두 가능
  - SafeZoneService에 validateGuardianAccess() 추가 (existsByWardKeyAndCaregiverKeyAndCareRole 활용)
  - 관련 테스트 케이스(MANAGER 접근 허용/차단) 보완



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* SafeZone 기능 추가: 보호자가 관리 중인 간호 대상자 구역 내에서 안전 지역을 생성, 조회, 수정, 삭제할 수 있습니다. 각 안전 지역의 반경은 4가지 옵션(500m, 1000m, 1500m, 2000m) 중에서 선택하여 설정할 수 있습니다.

* 위치 정보 수집 간격 설정 기능 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/brian506/re-caring/pull/85)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->