### PR TITLE
[Feature]: 케어 관계 삭제 API 구현

### DIFF
--- a/.claude/rules/forbidden.md
+++ b/.claude/rules/forbidden.md
@@ -37,6 +37,13 @@
   - `spring.jpa.hibernate.ddl-auto=validate` — 스키마 불일치 시 시작 즉시 충돌
   - `apply-ddl.sh` 실행 후 `Status: Success` 확인 전까지 다음 단계 진행 금지
 
+## Swagger / API Documentation
+
+- **Controller 메서드에 `@ApiResponses`를 사용하면 안 된다**
+  - 에러 응답은 `ErrorType`에 집중 관리하며, Swagger에 개별 응답 코드를 나열하지 않는다
+  - `@Operation(summary, description)`만 허용
+  - 탐지: Controller 파일에서 `@ApiResponses` 패턴
+
 ## Code Structure
 
 - **클래스 내부에 중첩 타입을 선언하면 안 된다**

--- a/.claude/skills/feature/references/snapshot.md
+++ b/.claude/skills/feature/references/snapshot.md
@@ -1,6 +1,6 @@
 # 프로젝트 스냅샷
 
-> 마지막 업데이트: 2026-05-11. 기능 추가·수정 시 해당 섹션을 갱신한다.
+> 마지막 업데이트: 2026-05-13. 기능 추가·수정 시 해당 섹션을 갱신한다.
 
 ## 도메인별 패키지 현황
 
@@ -34,6 +34,8 @@
 | Care | PATCH | `/api/v1/care/requests/{key}/reject` | 케어 요청 거절 |
 | Care | GET | `/api/v1/care/wards` | 내 보호대상자 목록 |
 | Care | GET | `/api/v1/care/wards/{wardKey}/caregivers` | 보호자/관리자 목록 |
+| Care | DELETE | `/api/v1/care/wards/{wardKey}` | 보호 대상자 케어 관계 삭제 (GUARDIAN, MANAGER) |
+| Care | DELETE | `/api/v1/care/wards/{wardKey}/caregivers/{caregiverKey}` | 특정 보호자/관리자 케어 관계 삭제 (GUARDIAN only) |
 | Device | POST | `/api/v1/device/token` | Device Token 발급 (WARD, JWT 인증) |
 | Location | POST | `/api/v1/location/gps` | GPS 좌표 전송 (WARD, Device Token 인증) |
 | Location | GET | `/api/v1/location/stream/{wardKey}` | SSE 실시간 위치 스트림 (GUARDIAN) |

--- a/src/main/generated/com/recaring/safezone/dataaccess/entity/QSafeZone.java
+++ b/src/main/generated/com/recaring/safezone/dataaccess/entity/QSafeZone.java
@@ -1,0 +1,65 @@
+package com.recaring.safezone.dataaccess.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.dsl.StringTemplate;
+
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.annotations.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QSafeZone is a Querydsl query type for SafeZone
+ */
+@SuppressWarnings("this-escape")
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSafeZone extends EntityPathBase<SafeZone> {
+
+    private static final long serialVersionUID = 1339573241L;
+
+    public static final QSafeZone safeZone = new QSafeZone("safeZone");
+
+    public final com.recaring.common.entity.QBaseEntity _super = new com.recaring.common.entity.QBaseEntity(this);
+
+    public final StringPath address = createString("address");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = _super.deletedAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Double> latitude = createNumber("latitude", Double.class);
+
+    public final NumberPath<Double> longitude = createNumber("longitude", Double.class);
+
+    public final StringPath name = createString("name");
+
+    public final EnumPath<SafeZoneRadius> radius = createEnum("radius", SafeZoneRadius.class);
+
+    public final StringPath safeZoneKey = createString("safeZoneKey");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final StringPath wardMemberKey = createString("wardMemberKey");
+
+    public QSafeZone(String variable) {
+        super(SafeZone.class, forVariable(variable));
+    }
+
+    public QSafeZone(Path<? extends SafeZone> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QSafeZone(PathMetadata metadata) {
+        super(SafeZone.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/recaring/care/business/CareRelationshipService.java
+++ b/src/main/java/com/recaring/care/business/CareRelationshipService.java
@@ -2,6 +2,7 @@ package com.recaring.care.business;
 
 import com.recaring.care.implement.CareRelationshipReader;
 import com.recaring.care.implement.CareRelationshipValidator;
+import com.recaring.care.implement.CareRelationshipWriter;
 import com.recaring.care.vo.CaregiverInfo;
 import com.recaring.care.vo.WardInfo;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import java.util.List;
 public class CareRelationshipService {
 
     private final CareRelationshipReader careRelationshipReader;
+    private final CareRelationshipWriter careRelationshipWriter;
     private final CareRelationshipValidator careRelationshipValidator;
 
     public List<WardInfo> getMyWards(String memberKey) {
@@ -23,5 +25,15 @@ public class CareRelationshipService {
     public List<CaregiverInfo> getCaregivers(String wardKey, String requesterKey) {
         careRelationshipValidator.validateCaregiverViewAccess(requesterKey, wardKey);
         return careRelationshipReader.findCaregiverInfos(wardKey);
+    }
+
+    public void removeWard(String guardianKey, String wardKey) {
+        careRelationshipValidator.validateIsCaregiver(guardianKey, wardKey);
+        careRelationshipWriter.delete(wardKey, guardianKey);
+    }
+
+    public void removeCaregiver(String guardianKey, String wardKey, String caregiverKey) {
+        careRelationshipValidator.validateIsGuardianRole(guardianKey, wardKey);
+        careRelationshipWriter.delete(wardKey, caregiverKey);
     }
 }

--- a/src/main/java/com/recaring/care/controller/CareController.java
+++ b/src/main/java/com/recaring/care/controller/CareController.java
@@ -11,7 +11,6 @@ import com.recaring.security.vo.AuthMember;
 import com.recaring.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -138,5 +137,32 @@ public class CareController {
                 .map(CaregiverResponse::from)
                 .toList();
         return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    @Operation(
+            summary = "보호 대상자(Ward) 케어 관계 삭제",
+            description = "보호자/관리자가 특정 보호 대상자와의 케어 관계를 삭제합니다. [GUARDIAN 전용]"
+    )
+    @DeleteMapping("/wards/{wardKey}")
+    public ResponseEntity<ApiResponse<Void>> removeWard(
+            @AuthMember String memberKey,
+            @Parameter(description = "보호 대상자 memberKey") @PathVariable String wardKey
+    ) {
+        careRelationshipService.removeWard(memberKey, wardKey);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @Operation(
+            summary = "보호자/관리자(Caregiver) 케어 관계 삭제",
+            description = "보호자(GUARDIAN CareRole)가 특정 보호 대상자에 연결된 보호자 또는 관리자를 케어 관계에서 삭제합니다. [GUARDIAN 전용]"
+    )
+    @DeleteMapping("/wards/{wardKey}/caregivers/{caregiverKey}")
+    public ResponseEntity<ApiResponse<Void>> removeCaregiver(
+            @AuthMember String memberKey,
+            @Parameter(description = "보호 대상자 memberKey") @PathVariable String wardKey,
+            @Parameter(description = "삭제할 보호자/관리자 memberKey") @PathVariable String caregiverKey
+    ) {
+        careRelationshipService.removeCaregiver(memberKey, wardKey, caregiverKey);
+        return ResponseEntity.ok(ApiResponse.success());
     }
 }

--- a/src/main/java/com/recaring/care/dataaccess/repository/custom/CareRelationshipRepositoryCustom.java
+++ b/src/main/java/com/recaring/care/dataaccess/repository/custom/CareRelationshipRepositoryCustom.java
@@ -4,6 +4,7 @@ import com.recaring.care.dataaccess.entity.CareRelationship;
 import com.recaring.care.dataaccess.entity.CareRole;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CareRelationshipRepositoryCustom {
 
@@ -14,4 +15,6 @@ public interface CareRelationshipRepositoryCustom {
     boolean existsByWardKeyAndCaregiverKeyAndCareRole(String wardKey, String caregiverKey, CareRole careRole);
 
     boolean existsByWardKeyAndCaregiverKey(String wardKey, String caregiverKey);
+
+    Optional<CareRelationship> findByWardKeyAndCaregiverKey(String wardKey, String caregiverKey);
 }

--- a/src/main/java/com/recaring/care/dataaccess/repository/custom/CareRelationshipRepositoryCustomImpl.java
+++ b/src/main/java/com/recaring/care/dataaccess/repository/custom/CareRelationshipRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import com.recaring.care.dataaccess.entity.CareRole;
 import com.recaring.support.repository.QuerydslRepositorySupport;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.recaring.care.dataaccess.entity.QCareRelationship.careRelationship;
 
@@ -52,5 +53,16 @@ public class CareRelationshipRepositoryCustomImpl extends QuerydslRepositorySupp
                 )
                 .fetchFirst();
         return result != null;
+    }
+
+    @Override
+    public Optional<CareRelationship> findByWardKeyAndCaregiverKey(String wardKey, String caregiverKey) {
+        CareRelationship result = selectFrom(careRelationship)
+                .where(
+                        careRelationship.wardMemberKey.eq(wardKey),
+                        careRelationship.caregiverMemberKey.eq(caregiverKey)
+                )
+                .fetchFirst();
+        return Optional.ofNullable(result);
     }
 }

--- a/src/main/java/com/recaring/care/implement/CareRelationshipValidator.java
+++ b/src/main/java/com/recaring/care/implement/CareRelationshipValidator.java
@@ -61,6 +61,20 @@ public class CareRelationshipValidator {
         }
     }
 
+    public void validateIsCaregiver(String requesterKey, String wardKey) {
+        boolean isCaregiver = careRelationshipRepository.existsByWardKeyAndCaregiverKey(wardKey, requesterKey);
+        if (!isCaregiver) {
+            throw new AppException(ErrorType.NOT_FOUND_CARE_RELATIONSHIP);
+        }
+    }
+
+    public void validateIsGuardianRole(String requesterKey, String wardKey) {
+        boolean isGuardian = careRelationshipRepository.existsByWardKeyAndCaregiverKeyAndCareRole(wardKey, requesterKey, CareRole.GUARDIAN);
+        if (!isGuardian) {
+            throw new AppException(ErrorType.NOT_GUARDIAN_ROLE_IN_CARE);
+        }
+    }
+
     private void checkRoleLimit(List<CareRelationship> relationships, CareRole role, int maxCount) {
         long count = relationships.stream()
                 .filter(r -> r.getCareRole() == role)

--- a/src/main/java/com/recaring/care/implement/CareRelationshipWriter.java
+++ b/src/main/java/com/recaring/care/implement/CareRelationshipWriter.java
@@ -6,6 +6,8 @@ import com.recaring.care.vo.CareRelationshipRegistration;
 import com.recaring.member.dataaccess.entity.Member;
 import com.recaring.member.dataaccess.entity.MemberRole;
 import com.recaring.member.implement.MemberReader;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,5 +30,13 @@ public class CareRelationshipWriter {
         careRelationshipRepository.save(
                 CareRelationship.of(registration.wardMemberKey(), registration.caregiverKey(), registration.careRole())
         );
+    }
+
+    @Transactional
+    public void delete(String wardKey, String caregiverKey) {
+        CareRelationship relationship = careRelationshipRepository
+                .findByWardKeyAndCaregiverKey(wardKey, caregiverKey)
+                .orElseThrow(() -> new AppException(ErrorType.NOT_FOUND_CARE_RELATIONSHIP));
+        relationship.delete();
     }
 }

--- a/src/main/java/com/recaring/support/exception/ErrorCode.java
+++ b/src/main/java/com/recaring/support/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 
     // Care (E5xxx) - 케어 관계, 초대
     E5000, E5001, E5002, E5003, E5004, E5005, E5006, E5007, E5008, E5009, E5010,
+    E5011, E5012,
 
     // Location (E6xxx) - GPS, SSE
     E6000, E6001, E6002,

--- a/src/main/java/com/recaring/support/exception/ErrorType.java
+++ b/src/main/java/com/recaring/support/exception/ErrorType.java
@@ -63,6 +63,8 @@ public enum ErrorType {
     INVALID_CAREGIVER_ROLE(HttpStatus.BAD_REQUEST, ErrorCode.E5008, "보호자로 가입한 회원만 보호자/관리자로 추가할 수 있습니다.", LogLevel.WARN),
     ALREADY_PENDING_CARE_REQUEST(HttpStatus.BAD_REQUEST, ErrorCode.E5009, "이미 대기 중인 케어 요청이 존재합니다.", LogLevel.WARN),
     WARD_KEY_REQUIRED(HttpStatus.BAD_REQUEST, ErrorCode.E5010, "보호자를 추가하려면 보호 대상자 키가 필요합니다.", LogLevel.WARN),
+    NOT_FOUND_CARE_RELATIONSHIP(HttpStatus.BAD_REQUEST, ErrorCode.E5011, "존재하지 않는 케어 관계입니다.", LogLevel.WARN),
+    NOT_GUARDIAN_ROLE_IN_CARE(HttpStatus.FORBIDDEN, ErrorCode.E5012, "해당 보호 대상자의 보호자(GUARDIAN) 역할이 아닙니다.", LogLevel.WARN),
 
     // Location (E6xxx)
     NOT_WARD_MEMBER(HttpStatus.FORBIDDEN, ErrorCode.E6000, "보호 대상자로 가입한 회원만 GPS를 전송할 수 있습니다.", LogLevel.WARN),

--- a/src/test/java/com/recaring/care/business/CareRelationshipServiceTest.java
+++ b/src/test/java/com/recaring/care/business/CareRelationshipServiceTest.java
@@ -3,6 +3,7 @@ package com.recaring.care.business;
 import com.recaring.care.fixture.CareFixture;
 import com.recaring.care.implement.CareRelationshipReader;
 import com.recaring.care.implement.CareRelationshipValidator;
+import com.recaring.care.implement.CareRelationshipWriter;
 import com.recaring.care.vo.CaregiverInfo;
 import com.recaring.care.vo.WardInfo;
 import com.recaring.support.exception.AppException;
@@ -30,6 +31,9 @@ class CareRelationshipServiceTest {
 
     @Mock
     private CareRelationshipReader careRelationshipReader;
+
+    @Mock
+    private CareRelationshipWriter careRelationshipWriter;
 
     @Mock
     private CareRelationshipValidator careRelationshipValidator;
@@ -77,5 +81,63 @@ class CareRelationshipServiceTest {
                 .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_GUARDIAN_OF_WARD);
 
         then(careRelationshipReader).should(times(0)).findCaregiverInfos(any());
+    }
+
+    // ── removeWard ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("보호 대상자 케어 관계 삭제 - 검증 통과 후 Writer의 delete가 호출된다")
+    void removeWard_validates_then_deletes() {
+        careRelationshipService.removeWard(CareFixture.GUARDIAN_MEMBER_KEY, CareFixture.WARD_MEMBER_KEY);
+
+        then(careRelationshipValidator).should(times(1))
+                .validateIsCaregiver(CareFixture.GUARDIAN_MEMBER_KEY, CareFixture.WARD_MEMBER_KEY);
+        then(careRelationshipWriter).should(times(1))
+                .delete(CareFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY);
+    }
+
+    @Test
+    @DisplayName("보호 대상자 케어 관계 삭제 - 케어 관계가 없으면 예외가 전파된다")
+    void removeWard_propagates_exception_when_not_caregiver() {
+        willThrow(new AppException(ErrorType.NOT_FOUND_CARE_RELATIONSHIP))
+                .given(careRelationshipValidator)
+                .validateIsCaregiver(CareFixture.GUARDIAN_MEMBER_KEY, CareFixture.WARD_MEMBER_KEY);
+
+        assertThatThrownBy(() ->
+                careRelationshipService.removeWard(CareFixture.GUARDIAN_MEMBER_KEY, CareFixture.WARD_MEMBER_KEY))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_FOUND_CARE_RELATIONSHIP);
+
+        then(careRelationshipWriter).should(times(0)).delete(any(), any());
+    }
+
+    // ── removeCaregiver ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("보호자/관계자 케어 관계 삭제 - GUARDIAN 역할 검증 후 Writer의 delete가 호출된다")
+    void removeCaregiver_validates_guardian_role_then_deletes() {
+        careRelationshipService.removeCaregiver(
+                CareFixture.GUARDIAN_MEMBER_KEY, CareFixture.WARD_MEMBER_KEY, CareFixture.MANAGER_MEMBER_KEY);
+
+        then(careRelationshipValidator).should(times(1))
+                .validateIsGuardianRole(CareFixture.GUARDIAN_MEMBER_KEY, CareFixture.WARD_MEMBER_KEY);
+        then(careRelationshipWriter).should(times(1))
+                .delete(CareFixture.WARD_MEMBER_KEY, CareFixture.MANAGER_MEMBER_KEY);
+    }
+
+    @Test
+    @DisplayName("보호자/관계자 케어 관계 삭제 - 요청자가 GUARDIAN 역할이 아니면 예외가 전파된다")
+    void removeCaregiver_propagates_exception_when_not_guardian_role() {
+        willThrow(new AppException(ErrorType.NOT_GUARDIAN_ROLE_IN_CARE))
+                .given(careRelationshipValidator)
+                .validateIsGuardianRole(CareFixture.MANAGER_MEMBER_KEY, CareFixture.WARD_MEMBER_KEY);
+
+        assertThatThrownBy(() ->
+                careRelationshipService.removeCaregiver(
+                        CareFixture.MANAGER_MEMBER_KEY, CareFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_GUARDIAN_ROLE_IN_CARE);
+
+        then(careRelationshipWriter).should(times(0)).delete(any(), any());
     }
 }

--- a/src/test/java/com/recaring/care/controller/CareControllerTest.java
+++ b/src/test/java/com/recaring/care/controller/CareControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+@org.junit.jupiter.api.Tag("integration")
 @DisplayName("CareController HTTP 통합 테스트")
 class CareControllerTest extends AbstractIntegrationTest {
 
@@ -236,5 +237,94 @@ class CareControllerTest extends AbstractIntegrationTest {
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + strangerToken)
                 .exchange()
                 .expectStatus().isForbidden();
+    }
+
+    // ── 보호 대상자 케어 관계 삭제 ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("DELETE /api/v1/care/wards/{wardKey} - 보호자가 대상자와의 케어 관계를 삭제한다")
+    void removeWard_success() {
+        CareRelationship relationship = CareFixture.createGuardianRelationship(
+                ward.getMemberKey(), guardian.getMemberKey());
+        careRelationshipRepository.save(relationship);
+
+        client.delete()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + guardianToken)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("SUCCESS");
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/care/wards/{wardKey} - 케어 관계가 없으면 4xx가 반환된다")
+    void removeWard_fails_when_relationship_not_found() {
+        client.delete()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + guardianToken)
+                .exchange()
+                .expectStatus().is4xxClientError();
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/care/wards/{wardKey} - 인증 없이 요청하면 401이 반환된다")
+    void removeWard_without_auth_returns_401() {
+        client.delete()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey())
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    // ── 보호자/관계자 케어 관계 삭제 ───────────────────────────────────────
+
+    @Test
+    @DisplayName("DELETE /api/v1/care/wards/{wardKey}/caregivers/{caregiverKey} - GUARDIAN이 관리자를 삭제한다")
+    void removeCaregiver_success() {
+        Member manager = memberRepository.save(CareFixture.createGuardianMember(CareFixture.MANAGER_PHONE));
+        localAuthRepository.save(LocalAuth.of(manager.getMemberKey(), "manager@test.com",
+                passwordEncoder.encode("password1!")));
+
+        careRelationshipRepository.save(
+                CareFixture.createGuardianRelationship(ward.getMemberKey(), guardian.getMemberKey()));
+        careRelationshipRepository.save(
+                CareFixture.createManagerRelationship(ward.getMemberKey(), manager.getMemberKey()));
+
+        client.delete()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/caregivers/" + manager.getMemberKey())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + guardianToken)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("SUCCESS");
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/care/wards/{wardKey}/caregivers/{caregiverKey} - GUARDIAN 역할이 아니면 4xx가 반환된다")
+    void removeCaregiver_fails_when_not_guardian_role() {
+        Member manager = memberRepository.save(CareFixture.createGuardianMember(CareFixture.MANAGER_PHONE));
+        localAuthRepository.save(LocalAuth.of(manager.getMemberKey(), "manager@test.com",
+                passwordEncoder.encode("password1!")));
+        String managerToken = extractAccessToken("manager@test.com", "password1!");
+
+        careRelationshipRepository.save(
+                CareFixture.createGuardianRelationship(ward.getMemberKey(), guardian.getMemberKey()));
+        careRelationshipRepository.save(
+                CareFixture.createManagerRelationship(ward.getMemberKey(), manager.getMemberKey()));
+
+        client.delete()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/caregivers/" + guardian.getMemberKey())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + managerToken)
+                .exchange()
+                .expectStatus().is4xxClientError();
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/care/wards/{wardKey}/caregivers/{caregiverKey} - 인증 없이 요청하면 401이 반환된다")
+    void removeCaregiver_without_auth_returns_401() {
+        client.delete()
+                .uri("/api/v1/care/wards/" + ward.getMemberKey() + "/caregivers/" + guardian.getMemberKey())
+                .exchange()
+                .expectStatus().isUnauthorized();
     }
 }

--- a/src/test/java/com/recaring/care/implement/CareRelationshipValidatorTest.java
+++ b/src/test/java/com/recaring/care/implement/CareRelationshipValidatorTest.java
@@ -124,6 +124,64 @@ class CareRelationshipValidatorTest {
                 .hasFieldOrPropertyWithValue("errorType", ErrorType.ALREADY_CARE_RELATIONSHIP);
     }
 
+    // ── validateIsCaregiver ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("케어 관계 보호자 검증 - 케어 관계가 존재하면 정상 통과한다")
+    void validateIsCaregiver_success() {
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
+                CareFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY))
+                .willReturn(true);
+
+        assertThatCode(() ->
+                careRelationshipValidator.validateIsCaregiver(
+                        CareFixture.GUARDIAN_MEMBER_KEY, CareFixture.WARD_MEMBER_KEY))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("케어 관계 보호자 검증 - 케어 관계가 없으면 예외가 발생한다")
+    void validateIsCaregiver_fails_when_relationship_not_found() {
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKey(
+                CareFixture.WARD_MEMBER_KEY, "stranger-key"))
+                .willReturn(false);
+
+        assertThatThrownBy(() ->
+                careRelationshipValidator.validateIsCaregiver(
+                        "stranger-key", CareFixture.WARD_MEMBER_KEY))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_FOUND_CARE_RELATIONSHIP);
+    }
+
+    // ── validateIsGuardianRole ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("보호자 역할 검증 - CareRole이 GUARDIAN이면 정상 통과한다")
+    void validateIsGuardianRole_success() {
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKeyAndCareRole(
+                CareFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY, CareRole.GUARDIAN))
+                .willReturn(true);
+
+        assertThatCode(() ->
+                careRelationshipValidator.validateIsGuardianRole(
+                        CareFixture.GUARDIAN_MEMBER_KEY, CareFixture.WARD_MEMBER_KEY))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("보호자 역할 검증 - CareRole이 GUARDIAN이 아니면 예외가 발생한다")
+    void validateIsGuardianRole_fails_when_not_guardian_role() {
+        given(careRelationshipRepository.existsByWardKeyAndCaregiverKeyAndCareRole(
+                CareFixture.WARD_MEMBER_KEY, CareFixture.MANAGER_MEMBER_KEY, CareRole.GUARDIAN))
+                .willReturn(false);
+
+        assertThatThrownBy(() ->
+                careRelationshipValidator.validateIsGuardianRole(
+                        CareFixture.MANAGER_MEMBER_KEY, CareFixture.WARD_MEMBER_KEY))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_GUARDIAN_ROLE_IN_CARE);
+    }
+
     // ── validateCaregiverViewAccess ────────────────────────────────────────
 
     @Test

--- a/src/test/java/com/recaring/care/implement/CareRelationshipWriterTest.java
+++ b/src/test/java/com/recaring/care/implement/CareRelationshipWriterTest.java
@@ -1,0 +1,71 @@
+package com.recaring.care.implement;
+
+import com.recaring.care.dataaccess.entity.CareRelationship;
+import com.recaring.care.dataaccess.repository.CareRelationshipRepository;
+import com.recaring.care.fixture.CareFixture;
+import com.recaring.member.implement.MemberReader;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CareRelationshipWriter 단위 테스트")
+class CareRelationshipWriterTest {
+
+    @InjectMocks
+    private CareRelationshipWriter careRelationshipWriter;
+
+    @Mock
+    private CareRelationshipRepository careRelationshipRepository;
+
+    @Mock
+    private MemberReader memberReader;
+
+    @Mock
+    private CareRelationshipValidator relationshipValidator;
+
+    // ── delete ─────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("케어 관계 삭제 - 관계가 존재하면 entity.delete()가 호출된다")
+    void delete_success() {
+        CareRelationship relationship = CareFixture.createGuardianRelationship(
+                CareFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY);
+        given(careRelationshipRepository.findByWardKeyAndCaregiverKey(
+                CareFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY))
+                .willReturn(Optional.of(relationship));
+
+        assertThatCode(() ->
+                careRelationshipWriter.delete(CareFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY))
+                .doesNotThrowAnyException();
+
+        then(careRelationshipRepository).should(times(1))
+                .findByWardKeyAndCaregiverKey(CareFixture.WARD_MEMBER_KEY, CareFixture.GUARDIAN_MEMBER_KEY);
+    }
+
+    @Test
+    @DisplayName("케어 관계 삭제 - 관계가 존재하지 않으면 예외가 발생한다")
+    void delete_fails_when_relationship_not_found() {
+        given(careRelationshipRepository.findByWardKeyAndCaregiverKey(
+                CareFixture.WARD_MEMBER_KEY, "unknown-key"))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                careRelationshipWriter.delete(CareFixture.WARD_MEMBER_KEY, "unknown-key"))
+                .isInstanceOf(AppException.class)
+                .hasFieldOrPropertyWithValue("errorType", ErrorType.NOT_FOUND_CARE_RELATIONSHIP);
+    }
+}


### PR DESCRIPTION
## 개요
보호자가 케어 대상자를 삭제하거나, 보호자/관리자가 케어 관계에서 스스로 삭제할 수 있는 API를 구현했습니다.
소프트 딜리트 전략을 적용하며 권한 검증 로직을 포함합니다.

## 변경 사항
- `DELETE /api/v1/care/wards/{wardKey}` 엔드포인트 추가 (보호 대상자 케어 관계 삭제)
- `DELETE /api/v1/care/wards/{wardKey}/caregivers/{caregiverKey}` 엔드포인트 추가 (보호자/관리자 케어 관계 삭제)
- `CareRelationshipService.removeWard()`, `removeCaregiver()` 메서드 추가
- `CareRelationshipValidator.validateIsCaregiver()`, `validateIsGuardianRole()` 메서드 추가
- `CareRelationshipWriter.delete()` 소프트 딜리트 구현
- `CareRelationshipRepositoryCustom`에 조회 메서드 3개 추가 및 QueryDSL 구현
- `ErrorCode` E5011, E5012 및 `ErrorType` NOT_FOUND_CARE_RELATIONSHIP, NOT_GUARDIAN_ROLE_IN_CARE 추가
- `CareController`에서 `@ApiResponses` 어노테이션 제거 (forbidden 규칙 반영)
- 단위 테스트 및 통합 테스트 보강 (CareRelationshipWriterTest 신규, 기존 테스트 케이스 추가)

## 관련 이슈
closes #88

## 테스트
- [x] 단위 테스트 통과 (`./gradlew test`)
- [x] 전체 빌드 성공 (`./gradlew build`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 보호 대상자의 케어 관계를 삭제할 수 있는 API 엔드포인트 추가
  * 보호 대상자의 보호자/관리자 관계를 개별 삭제할 수 있는 API 엔드포인트 추가
  * 삭제 작업 시 권한 검증 추가 (보호자 역할 확인)

* **문서**
  * API 문서에 새로운 DELETE 엔드포인트 2개 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/brian506/re-caring/pull/89)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->