### PR TITLE
feature[#ST-004]: add FCM notification delivery

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 	// coolSMS
 	implementation 'net.nurigo:sdk:4.3.0'
 
+	// Firebase
+	implementation 'com.google.firebase:firebase-admin:9.8.0'
+
 	// AWS SDK v2
 	implementation platform('software.amazon.awssdk:bom:2.25.60')
 	implementation 'software.amazon.awssdk:sns'

--- a/docs/st-004-fcm-notification-delivery-ddl.sql
+++ b/docs/st-004-fcm-notification-delivery-ddl.sql
@@ -1,0 +1,63 @@
+CREATE TABLE IF NOT EXISTS fcm_device_tokens (
+    fcm_device_token_id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP,
+    member_key VARCHAR(255) NOT NULL,
+    recipient_type VARCHAR(20) NOT NULL,
+    token VARCHAR(512) NOT NULL UNIQUE,
+    platform VARCHAR(20),
+    active BOOLEAN NOT NULL,
+    last_used_at TIMESTAMP,
+    deactivated_at TIMESTAMP,
+    deactivation_reason VARCHAR(100)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fcm_device_tokens_member_type_active
+    ON fcm_device_tokens (member_key, recipient_type, active);
+
+CREATE TABLE IF NOT EXISTS notifications (
+    notification_id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP,
+    notification_key VARCHAR(255) NOT NULL UNIQUE,
+    event_type VARCHAR(100) NOT NULL,
+    title VARCHAR(200) NOT NULL,
+    body VARCHAR(1000) NOT NULL,
+    data_payload TEXT,
+    status VARCHAR(20) NOT NULL,
+    requested_at TIMESTAMP NOT NULL,
+    sent_at TIMESTAMP,
+    failure_code VARCHAR(100),
+    failure_reason VARCHAR(1000)
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_status_requested_at
+    ON notifications (status, requested_at);
+
+CREATE TABLE IF NOT EXISTS notification_deliveries (
+    notification_delivery_id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP,
+    notification_id BIGINT NOT NULL REFERENCES notifications (notification_id),
+    recipient_member_key VARCHAR(255) NOT NULL,
+    recipient_type VARCHAR(20) NOT NULL,
+    fcm_device_token_id BIGINT,
+    token_snapshot VARCHAR(512) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    fcm_message_id VARCHAR(255),
+    failure_code VARCHAR(100),
+    failure_reason VARCHAR(1000),
+    attempt_count INTEGER NOT NULL,
+    retryable BOOLEAN NOT NULL,
+    next_retry_at TIMESTAMP,
+    sent_at TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_deliveries_notification_id
+    ON notification_deliveries (notification_id);
+
+CREATE INDEX IF NOT EXISTS idx_notification_deliveries_retry
+    ON notification_deliveries (status, retryable, next_retry_at);

--- a/src/main/java/com/recaring/config/auth/SecurityConfig.java
+++ b/src/main/java/com/recaring/config/auth/SecurityConfig.java
@@ -81,6 +81,7 @@ public class SecurityConfig {
                                 mvc.matcher(HttpMethod.POST, "/api/v1/care/requests"),
                                 mvc.matcher(HttpMethod.GET,  "/api/v1/care/wards"),
                                 mvc.matcher(HttpMethod.POST, "/api/v1/members/phones"),
+                                mvc.matcher(HttpMethod.PUT,  "/api/v1/notifications/device-tokens"),
                                 mvc.matcher(HttpMethod.GET,  "/api/v1/location/settings/{wardKey}/collection-interval"),
                                 mvc.matcher(HttpMethod.PATCH, "/api/v1/location/settings/{wardKey}/collection-interval"),
                                 // SafeZone (GUARDIAN/MANAGER 모두 MemberRole.GUARDIAN)

--- a/src/main/java/com/recaring/config/infra/FirebaseConfig.java
+++ b/src/main/java/com/recaring/config/infra/FirebaseConfig.java
@@ -26,7 +26,7 @@ public class FirebaseConfig {
             throw new IllegalStateException("firebase.service-account-json-base64 is required when firebase.enabled=true");
         }
 
-        byte[] decoded = Base64.getDecoder().decode(serviceAccountJsonBase64);
+        byte[] decoded = decodeServiceAccount();
         GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(decoded));
         FirebaseOptions options = FirebaseOptions.builder()
                 .setCredentials(credentials)
@@ -41,5 +41,16 @@ public class FirebaseConfig {
     @Bean
     public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
         return FirebaseMessaging.getInstance(firebaseApp);
+    }
+
+    private byte[] decodeServiceAccount() {
+        try {
+            return Base64.getDecoder().decode(serviceAccountJsonBase64);
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalStateException(
+                    "firebase.service-account-json-base64 must be valid Base64 encoded JSON.",
+                    exception
+            );
+        }
     }
 }

--- a/src/main/java/com/recaring/config/infra/FirebaseConfig.java
+++ b/src/main/java/com/recaring/config/infra/FirebaseConfig.java
@@ -1,0 +1,45 @@
+package com.recaring.config.infra;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+@Configuration
+@ConditionalOnProperty(prefix = "firebase", name = "enabled", havingValue = "true")
+public class FirebaseConfig {
+
+    @Value("${firebase.service-account-json-base64}")
+    private String serviceAccountJsonBase64;
+
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        if (serviceAccountJsonBase64 == null || serviceAccountJsonBase64.isBlank()) {
+            throw new IllegalStateException("firebase.service-account-json-base64 is required when firebase.enabled=true");
+        }
+
+        byte[] decoded = Base64.getDecoder().decode(serviceAccountJsonBase64);
+        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(decoded));
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(credentials)
+                .build();
+
+        if (FirebaseApp.getApps().isEmpty()) {
+            return FirebaseApp.initializeApp(options);
+        }
+        return FirebaseApp.getInstance();
+    }
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+}

--- a/src/main/java/com/recaring/notification/business/FcmDeviceTokenService.java
+++ b/src/main/java/com/recaring/notification/business/FcmDeviceTokenService.java
@@ -1,0 +1,18 @@
+package com.recaring.notification.business;
+
+import com.recaring.notification.business.command.UpsertFcmDeviceTokenCommand;
+import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
+import com.recaring.notification.implement.FcmDeviceTokenManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FcmDeviceTokenService {
+
+    private final FcmDeviceTokenManager fcmDeviceTokenManager;
+
+    public FcmDeviceToken upsert(UpsertFcmDeviceTokenCommand command) {
+        return fcmDeviceTokenManager.upsert(command);
+    }
+}

--- a/src/main/java/com/recaring/notification/business/NotificationSendResult.java
+++ b/src/main/java/com/recaring/notification/business/NotificationSendResult.java
@@ -1,0 +1,32 @@
+package com.recaring.notification.business;
+
+import com.recaring.notification.dataaccess.entity.Notification;
+import com.recaring.notification.dataaccess.entity.NotificationDelivery;
+import com.recaring.notification.dataaccess.entity.NotificationDeliveryStatus;
+import com.recaring.notification.dataaccess.entity.NotificationStatus;
+
+import java.util.List;
+
+public record NotificationSendResult(
+        String notificationKey,
+        NotificationStatus status,
+        long requestedCount,
+        long sentCount,
+        long failedCount
+) {
+    public static NotificationSendResult from(Notification notification, List<NotificationDelivery> deliveries) {
+        long sent = deliveries.stream()
+                .filter(delivery -> delivery.getStatus() == NotificationDeliveryStatus.SENT)
+                .count();
+        long failed = deliveries.stream()
+                .filter(delivery -> delivery.getStatus() == NotificationDeliveryStatus.FAILED)
+                .count();
+        return new NotificationSendResult(
+                notification.getNotificationKey(),
+                notification.getStatus(),
+                deliveries.size(),
+                sent,
+                failed
+        );
+    }
+}

--- a/src/main/java/com/recaring/notification/business/NotificationSendService.java
+++ b/src/main/java/com/recaring/notification/business/NotificationSendService.java
@@ -1,7 +1,5 @@
 package com.recaring.notification.business;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.recaring.notification.business.command.NotificationSendCommand;
 import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
 import com.recaring.notification.dataaccess.entity.Notification;
@@ -12,12 +10,10 @@ import com.recaring.notification.implement.FcmDeviceTokenReader;
 import com.recaring.notification.implement.FcmPushMessage;
 import com.recaring.notification.implement.FcmSendResult;
 import com.recaring.notification.implement.NotificationDeliveryManager;
+import com.recaring.notification.implement.NotificationPayloadSerializer;
 import com.recaring.notification.implement.NotificationWriter;
-import com.recaring.support.exception.AppException;
-import com.recaring.support.exception.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -25,16 +21,15 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NotificationSendService {
 
-    private final ObjectMapper objectMapper;
+    private final NotificationPayloadSerializer notificationPayloadSerializer;
     private final FcmDeviceTokenReader fcmDeviceTokenReader;
     private final FcmDeviceTokenManager fcmDeviceTokenManager;
     private final NotificationWriter notificationWriter;
     private final NotificationDeliveryManager notificationDeliveryManager;
     private final FcmClient fcmClient;
 
-    @Transactional
     public NotificationSendResult send(NotificationSendCommand command) {
-        String dataPayloadJson = serialize(command.dataPayload());
+        String dataPayloadJson = notificationPayloadSerializer.serialize(command.dataPayload());
         Notification notification = notificationWriter.addRequested(
                 command.eventType(),
                 command.title(),
@@ -59,17 +54,11 @@ public class NotificationSendService {
 
         notificationDeliveryManager.applyResults(deliveries, sendResult);
         fcmDeviceTokenManager.deactivateInvalidTokens(sendResult.invalidTokens());
-        tokens.forEach(FcmDeviceToken::touchLastUsedAt);
+        fcmDeviceTokenManager.touchLastUsedAt(tokens.stream()
+                .map(FcmDeviceToken::getToken)
+                .toList());
         notificationWriter.completeByDeliveries(notification, deliveries);
 
         return NotificationSendResult.from(notification, deliveries);
-    }
-
-    private String serialize(Object payload) {
-        try {
-            return objectMapper.writeValueAsString(payload);
-        } catch (JsonProcessingException exception) {
-            throw new AppException(ErrorType.NOTIFICATION_PAYLOAD_SERIALIZATION_FAILED);
-        }
     }
 }

--- a/src/main/java/com/recaring/notification/business/NotificationSendService.java
+++ b/src/main/java/com/recaring/notification/business/NotificationSendService.java
@@ -1,0 +1,75 @@
+package com.recaring.notification.business;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.recaring.notification.business.command.NotificationSendCommand;
+import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
+import com.recaring.notification.dataaccess.entity.Notification;
+import com.recaring.notification.dataaccess.entity.NotificationDelivery;
+import com.recaring.notification.implement.FcmClient;
+import com.recaring.notification.implement.FcmDeviceTokenManager;
+import com.recaring.notification.implement.FcmDeviceTokenReader;
+import com.recaring.notification.implement.FcmPushMessage;
+import com.recaring.notification.implement.FcmSendResult;
+import com.recaring.notification.implement.NotificationDeliveryManager;
+import com.recaring.notification.implement.NotificationWriter;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSendService {
+
+    private final ObjectMapper objectMapper;
+    private final FcmDeviceTokenReader fcmDeviceTokenReader;
+    private final FcmDeviceTokenManager fcmDeviceTokenManager;
+    private final NotificationWriter notificationWriter;
+    private final NotificationDeliveryManager notificationDeliveryManager;
+    private final FcmClient fcmClient;
+
+    @Transactional
+    public NotificationSendResult send(NotificationSendCommand command) {
+        String dataPayloadJson = serialize(command.dataPayload());
+        Notification notification = notificationWriter.addRequested(
+                command.eventType(),
+                command.title(),
+                command.body(),
+                dataPayloadJson
+        );
+
+        List<FcmDeviceToken> tokens = fcmDeviceTokenReader.findActiveRecipientTokens(
+                command.guardianMemberKeys(),
+                command.managerMemberKeys()
+        );
+        if (tokens.isEmpty()) {
+            notificationWriter.markFailedForNoActiveToken(notification);
+            return NotificationSendResult.from(notification, List.of());
+        }
+
+        List<NotificationDelivery> deliveries = notificationDeliveryManager.addRequested(notification, tokens);
+        FcmSendResult sendResult = fcmClient.send(
+                new FcmPushMessage(command.title(), command.body(), command.dataPayload()),
+                tokens.stream().map(FcmDeviceToken::getToken).toList()
+        );
+
+        notificationDeliveryManager.applyResults(deliveries, sendResult);
+        fcmDeviceTokenManager.deactivateInvalidTokens(sendResult.invalidTokens());
+        tokens.forEach(FcmDeviceToken::touchLastUsedAt);
+        notificationWriter.completeByDeliveries(notification, deliveries);
+
+        return NotificationSendResult.from(notification, deliveries);
+    }
+
+    private String serialize(Object payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException exception) {
+            throw new AppException(ErrorType.NOTIFICATION_PAYLOAD_SERIALIZATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/recaring/notification/business/command/NotificationSendCommand.java
+++ b/src/main/java/com/recaring/notification/business/command/NotificationSendCommand.java
@@ -1,0 +1,19 @@
+package com.recaring.notification.business.command;
+
+import java.util.List;
+import java.util.Map;
+
+public record NotificationSendCommand(
+        List<String> guardianMemberKeys,
+        List<String> managerMemberKeys,
+        String title,
+        String body,
+        Map<String, String> dataPayload,
+        String eventType
+) {
+    public NotificationSendCommand {
+        guardianMemberKeys = guardianMemberKeys == null ? List.of() : List.copyOf(guardianMemberKeys);
+        managerMemberKeys = managerMemberKeys == null ? List.of() : List.copyOf(managerMemberKeys);
+        dataPayload = dataPayload == null ? Map.of() : Map.copyOf(dataPayload);
+    }
+}

--- a/src/main/java/com/recaring/notification/business/command/UpsertFcmDeviceTokenCommand.java
+++ b/src/main/java/com/recaring/notification/business/command/UpsertFcmDeviceTokenCommand.java
@@ -1,0 +1,12 @@
+package com.recaring.notification.business.command;
+
+import com.recaring.notification.dataaccess.entity.FcmDevicePlatform;
+import com.recaring.notification.dataaccess.entity.NotificationRecipientType;
+
+public record UpsertFcmDeviceTokenCommand(
+        String memberKey,
+        NotificationRecipientType recipientType,
+        String token,
+        FcmDevicePlatform platform
+) {
+}

--- a/src/main/java/com/recaring/notification/controller/FcmDeviceTokenController.java
+++ b/src/main/java/com/recaring/notification/controller/FcmDeviceTokenController.java
@@ -1,0 +1,41 @@
+package com.recaring.notification.controller;
+
+import com.recaring.notification.business.FcmDeviceTokenService;
+import com.recaring.notification.controller.request.UpsertFcmDeviceTokenRequest;
+import com.recaring.notification.controller.response.FcmDeviceTokenResponse;
+import com.recaring.security.vo.AuthMember;
+import com.recaring.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications/device-tokens")
+@RequiredArgsConstructor
+@Tag(name = "FCM Device Token", description = "FCM device token API")
+public class FcmDeviceTokenController {
+
+    private final FcmDeviceTokenService fcmDeviceTokenService;
+
+    @Operation(
+            summary = "Upsert FCM device token",
+            description = "Registers or updates a guardian or manager FCM device token. [GUARDIAN, MANAGER]"
+    )
+    @PutMapping
+    public ResponseEntity<ApiResponse<FcmDeviceTokenResponse>> upsert(
+            @Parameter(hidden = true)
+            @AuthMember String memberKey,
+            @RequestBody UpsertFcmDeviceTokenRequest request
+    ) {
+        FcmDeviceTokenResponse response = FcmDeviceTokenResponse.from(
+                fcmDeviceTokenService.upsert(request.toCommand(memberKey))
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/recaring/notification/controller/request/UpsertFcmDeviceTokenRequest.java
+++ b/src/main/java/com/recaring/notification/controller/request/UpsertFcmDeviceTokenRequest.java
@@ -1,0 +1,17 @@
+package com.recaring.notification.controller.request;
+
+import com.recaring.notification.business.command.UpsertFcmDeviceTokenCommand;
+import com.recaring.notification.dataaccess.entity.FcmDevicePlatform;
+import com.recaring.notification.dataaccess.entity.NotificationRecipientType;
+
+public record UpsertFcmDeviceTokenRequest(
+        String token,
+
+        NotificationRecipientType recipientType,
+
+        FcmDevicePlatform platform
+) {
+    public UpsertFcmDeviceTokenCommand toCommand(String memberKey) {
+        return new UpsertFcmDeviceTokenCommand(memberKey, recipientType, token, platform);
+    }
+}

--- a/src/main/java/com/recaring/notification/controller/response/FcmDeviceTokenResponse.java
+++ b/src/main/java/com/recaring/notification/controller/response/FcmDeviceTokenResponse.java
@@ -1,0 +1,23 @@
+package com.recaring.notification.controller.response;
+
+import com.recaring.notification.dataaccess.entity.FcmDevicePlatform;
+import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
+import com.recaring.notification.dataaccess.entity.NotificationRecipientType;
+
+public record FcmDeviceTokenResponse(
+        Long id,
+        String memberKey,
+        NotificationRecipientType recipientType,
+        FcmDevicePlatform platform,
+        boolean active
+) {
+    public static FcmDeviceTokenResponse from(FcmDeviceToken token) {
+        return new FcmDeviceTokenResponse(
+                token.getId(),
+                token.getMemberKey(),
+                token.getRecipientType(),
+                token.getPlatform(),
+                token.isActive()
+        );
+    }
+}

--- a/src/main/java/com/recaring/notification/dataaccess/entity/FcmDevicePlatform.java
+++ b/src/main/java/com/recaring/notification/dataaccess/entity/FcmDevicePlatform.java
@@ -1,0 +1,7 @@
+package com.recaring.notification.dataaccess.entity;
+
+public enum FcmDevicePlatform {
+    ANDROID,
+    IOS,
+    WEB
+}

--- a/src/main/java/com/recaring/notification/dataaccess/entity/FcmDeviceToken.java
+++ b/src/main/java/com/recaring/notification/dataaccess/entity/FcmDeviceToken.java
@@ -1,0 +1,95 @@
+package com.recaring.notification.dataaccess.entity;
+
+import com.recaring.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "fcm_device_tokens")
+@SQLDelete(sql = "UPDATE fcm_device_tokens SET deleted_at = NOW() WHERE fcm_device_token_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FcmDeviceToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "fcm_device_token_id")
+    private Long id;
+
+    @Column(name = "member_key", nullable = false)
+    private String memberKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "recipient_type", nullable = false, length = 20)
+    private NotificationRecipientType recipientType;
+
+    @Column(name = "token", nullable = false, unique = true, length = 512)
+    private String token;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "platform", length = 20)
+    private FcmDevicePlatform platform;
+
+    @Column(name = "active", nullable = false)
+    private boolean active;
+
+    @Column(name = "last_used_at")
+    private LocalDateTime lastUsedAt;
+
+    @Column(name = "deactivated_at")
+    private LocalDateTime deactivatedAt;
+
+    @Column(name = "deactivation_reason", length = 100)
+    private String deactivationReason;
+
+    @Builder
+    public FcmDeviceToken(
+            String memberKey,
+            NotificationRecipientType recipientType,
+            String token,
+            FcmDevicePlatform platform
+    ) {
+        this.memberKey = memberKey;
+        this.recipientType = recipientType;
+        this.token = token;
+        this.platform = platform;
+        this.active = true;
+    }
+
+    public void assignTo(String memberKey, NotificationRecipientType recipientType, FcmDevicePlatform platform) {
+        this.memberKey = memberKey;
+        this.recipientType = recipientType;
+        this.platform = platform;
+        this.active = true;
+        this.deactivatedAt = null;
+        this.deactivationReason = null;
+        update();
+    }
+
+    public void touchLastUsedAt() {
+        this.lastUsedAt = LocalDateTime.now();
+        update();
+    }
+
+    public void deactivate(String reason) {
+        this.active = false;
+        this.deactivatedAt = LocalDateTime.now();
+        this.deactivationReason = reason;
+        update();
+    }
+}

--- a/src/main/java/com/recaring/notification/dataaccess/entity/Notification.java
+++ b/src/main/java/com/recaring/notification/dataaccess/entity/Notification.java
@@ -1,0 +1,102 @@
+package com.recaring.notification.dataaccess.entity;
+
+import com.recaring.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "notifications")
+@SQLDelete(sql = "UPDATE notifications SET deleted_at = NOW() WHERE notification_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @Column(name = "notification_key", nullable = false, unique = true)
+    private String notificationKey;
+
+    @Column(name = "event_type", nullable = false, length = 100)
+    private String eventType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "body", nullable = false, length = 1000)
+    private String body;
+
+    @Lob
+    @Column(name = "data_payload")
+    private String dataPayload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private NotificationStatus status;
+
+    @Column(name = "requested_at", nullable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    @Column(name = "failure_code", length = 100)
+    private String failureCode;
+
+    @Column(name = "failure_reason", length = 1000)
+    private String failureReason;
+
+    @Builder
+    public Notification(String eventType, String title, String body, String dataPayload) {
+        this.notificationKey = UUID.randomUUID().toString();
+        this.eventType = eventType;
+        this.title = title;
+        this.body = body;
+        this.dataPayload = dataPayload;
+        this.status = NotificationStatus.REQUESTED;
+        this.requestedAt = LocalDateTime.now();
+    }
+
+    public void markSent() {
+        this.status = NotificationStatus.SENT;
+        this.sentAt = LocalDateTime.now();
+        this.failureCode = null;
+        this.failureReason = null;
+        update();
+    }
+
+    public void markPartial(String failureCode, String failureReason) {
+        this.status = NotificationStatus.PARTIAL;
+        this.sentAt = LocalDateTime.now();
+        this.failureCode = failureCode;
+        this.failureReason = failureReason;
+        update();
+    }
+
+    public void markFailed(String failureCode, String failureReason) {
+        this.status = NotificationStatus.FAILED;
+        this.sentAt = LocalDateTime.now();
+        this.failureCode = failureCode;
+        this.failureReason = failureReason;
+        update();
+    }
+}

--- a/src/main/java/com/recaring/notification/dataaccess/entity/NotificationDelivery.java
+++ b/src/main/java/com/recaring/notification/dataaccess/entity/NotificationDelivery.java
@@ -1,0 +1,121 @@
+package com.recaring.notification.dataaccess.entity;
+
+import com.recaring.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "notification_deliveries")
+@SQLDelete(sql = "UPDATE notification_deliveries SET deleted_at = NOW() WHERE notification_delivery_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationDelivery extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_delivery_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notification_id", nullable = false)
+    private Notification notification;
+
+    @Column(name = "recipient_member_key", nullable = false)
+    private String recipientMemberKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "recipient_type", nullable = false, length = 20)
+    private NotificationRecipientType recipientType;
+
+    @Column(name = "fcm_device_token_id")
+    private Long fcmDeviceTokenId;
+
+    @Column(name = "token_snapshot", nullable = false, length = 512)
+    private String tokenSnapshot;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private NotificationDeliveryStatus status;
+
+    @Column(name = "fcm_message_id")
+    private String fcmMessageId;
+
+    @Column(name = "failure_code", length = 100)
+    private String failureCode;
+
+    @Column(name = "failure_reason", length = 1000)
+    private String failureReason;
+
+    @Column(name = "attempt_count", nullable = false)
+    private int attemptCount;
+
+    @Column(name = "retryable", nullable = false)
+    private boolean retryable;
+
+    @Column(name = "next_retry_at")
+    private LocalDateTime nextRetryAt;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    private NotificationDelivery(Notification notification, FcmDeviceToken token) {
+        this.notification = notification;
+        this.recipientMemberKey = token.getMemberKey();
+        this.recipientType = token.getRecipientType();
+        this.fcmDeviceTokenId = token.getId();
+        this.tokenSnapshot = token.getToken();
+        this.status = NotificationDeliveryStatus.REQUESTED;
+        this.attemptCount = 0;
+        this.retryable = false;
+    }
+
+    public static NotificationDelivery requested(Notification notification, FcmDeviceToken token) {
+        return new NotificationDelivery(notification, token);
+    }
+
+    public void markSent(String fcmMessageId, int attemptCount) {
+        this.status = NotificationDeliveryStatus.SENT;
+        this.fcmMessageId = fcmMessageId;
+        this.failureCode = null;
+        this.failureReason = null;
+        this.attemptCount = attemptCount;
+        this.retryable = false;
+        this.nextRetryAt = null;
+        this.sentAt = LocalDateTime.now();
+        update();
+    }
+
+    public void markFailed(
+            String failureCode,
+            String failureReason,
+            int attemptCount,
+            boolean retryable,
+            LocalDateTime nextRetryAt
+    ) {
+        this.status = NotificationDeliveryStatus.FAILED;
+        this.failureCode = failureCode;
+        this.failureReason = failureReason;
+        this.attemptCount = attemptCount;
+        this.retryable = retryable;
+        this.nextRetryAt = nextRetryAt;
+        this.sentAt = null;
+        update();
+    }
+}

--- a/src/main/java/com/recaring/notification/dataaccess/entity/NotificationDeliveryStatus.java
+++ b/src/main/java/com/recaring/notification/dataaccess/entity/NotificationDeliveryStatus.java
@@ -1,0 +1,7 @@
+package com.recaring.notification.dataaccess.entity;
+
+public enum NotificationDeliveryStatus {
+    REQUESTED,
+    SENT,
+    FAILED
+}

--- a/src/main/java/com/recaring/notification/dataaccess/entity/NotificationRecipientType.java
+++ b/src/main/java/com/recaring/notification/dataaccess/entity/NotificationRecipientType.java
@@ -1,0 +1,6 @@
+package com.recaring.notification.dataaccess.entity;
+
+public enum NotificationRecipientType {
+    GUARDIAN,
+    MANAGER
+}

--- a/src/main/java/com/recaring/notification/dataaccess/entity/NotificationStatus.java
+++ b/src/main/java/com/recaring/notification/dataaccess/entity/NotificationStatus.java
@@ -1,0 +1,8 @@
+package com.recaring.notification.dataaccess.entity;
+
+public enum NotificationStatus {
+    REQUESTED,
+    SENT,
+    PARTIAL,
+    FAILED
+}

--- a/src/main/java/com/recaring/notification/dataaccess/repository/FcmDeviceTokenRepository.java
+++ b/src/main/java/com/recaring/notification/dataaccess/repository/FcmDeviceTokenRepository.java
@@ -12,6 +12,8 @@ public interface FcmDeviceTokenRepository extends JpaRepository<FcmDeviceToken, 
 
     Optional<FcmDeviceToken> findByToken(String token);
 
+    List<FcmDeviceToken> findAllByTokenIn(Collection<String> tokens);
+
     List<FcmDeviceToken> findAllByMemberKeyInAndRecipientTypeAndActiveTrue(
             Collection<String> memberKeys,
             NotificationRecipientType recipientType

--- a/src/main/java/com/recaring/notification/dataaccess/repository/FcmDeviceTokenRepository.java
+++ b/src/main/java/com/recaring/notification/dataaccess/repository/FcmDeviceTokenRepository.java
@@ -1,0 +1,19 @@
+package com.recaring.notification.dataaccess.repository;
+
+import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
+import com.recaring.notification.dataaccess.entity.NotificationRecipientType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface FcmDeviceTokenRepository extends JpaRepository<FcmDeviceToken, Long> {
+
+    Optional<FcmDeviceToken> findByToken(String token);
+
+    List<FcmDeviceToken> findAllByMemberKeyInAndRecipientTypeAndActiveTrue(
+            Collection<String> memberKeys,
+            NotificationRecipientType recipientType
+    );
+}

--- a/src/main/java/com/recaring/notification/dataaccess/repository/NotificationDeliveryRepository.java
+++ b/src/main/java/com/recaring/notification/dataaccess/repository/NotificationDeliveryRepository.java
@@ -1,0 +1,16 @@
+package com.recaring.notification.dataaccess.repository;
+
+import com.recaring.notification.dataaccess.entity.NotificationDelivery;
+import com.recaring.notification.dataaccess.entity.NotificationDeliveryStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface NotificationDeliveryRepository extends JpaRepository<NotificationDelivery, Long> {
+
+    List<NotificationDelivery> findAllByStatusAndRetryableTrueAndNextRetryAtLessThanEqual(
+            NotificationDeliveryStatus status,
+            LocalDateTime nextRetryAt
+    );
+}

--- a/src/main/java/com/recaring/notification/dataaccess/repository/NotificationRepository.java
+++ b/src/main/java/com/recaring/notification/dataaccess/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package com.recaring.notification.dataaccess.repository;
+
+import com.recaring.notification.dataaccess.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    Optional<Notification> findByNotificationKey(String notificationKey);
+}

--- a/src/main/java/com/recaring/notification/implement/FcmClient.java
+++ b/src/main/java/com/recaring/notification/implement/FcmClient.java
@@ -1,0 +1,7 @@
+package com.recaring.notification.implement;
+
+import java.util.List;
+
+public interface FcmClient {
+    FcmSendResult send(FcmPushMessage message, List<String> tokens);
+}

--- a/src/main/java/com/recaring/notification/implement/FcmDeviceTokenManager.java
+++ b/src/main/java/com/recaring/notification/implement/FcmDeviceTokenManager.java
@@ -41,6 +41,15 @@ public class FcmDeviceTokenManager {
                 .ifPresent(deviceToken -> deviceToken.deactivate(UNREGISTERED_REASON)));
     }
 
+    @Transactional
+    public void touchLastUsedAt(Collection<String> tokens) {
+        if (tokens == null || tokens.isEmpty()) {
+            return;
+        }
+        fcmDeviceTokenRepository.findAllByTokenIn(tokens)
+                .forEach(FcmDeviceToken::touchLastUsedAt);
+    }
+
     private void validate(UpsertFcmDeviceTokenCommand command) {
         if (command.token() == null || command.token().isBlank()) {
             throw new AppException(ErrorType.INVALID_FCM_DEVICE_TOKEN);

--- a/src/main/java/com/recaring/notification/implement/FcmDeviceTokenManager.java
+++ b/src/main/java/com/recaring/notification/implement/FcmDeviceTokenManager.java
@@ -1,0 +1,52 @@
+package com.recaring.notification.implement;
+
+import com.recaring.notification.business.command.UpsertFcmDeviceTokenCommand;
+import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
+import com.recaring.notification.dataaccess.repository.FcmDeviceTokenRepository;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+
+@Component
+@RequiredArgsConstructor
+public class FcmDeviceTokenManager {
+
+    private static final String UNREGISTERED_REASON = "FCM_UNREGISTERED";
+
+    private final FcmDeviceTokenRepository fcmDeviceTokenRepository;
+
+    @Transactional
+    public FcmDeviceToken upsert(UpsertFcmDeviceTokenCommand command) {
+        validate(command);
+        return fcmDeviceTokenRepository.findByToken(command.token())
+                .map(existing -> {
+                    existing.assignTo(command.memberKey(), command.recipientType(), command.platform());
+                    return existing;
+                })
+                .orElseGet(() -> fcmDeviceTokenRepository.save(FcmDeviceToken.builder()
+                        .memberKey(command.memberKey())
+                        .recipientType(command.recipientType())
+                        .token(command.token())
+                        .platform(command.platform())
+                        .build()));
+    }
+
+    @Transactional
+    public void deactivateInvalidTokens(Collection<String> tokens) {
+        tokens.forEach(token -> fcmDeviceTokenRepository.findByToken(token)
+                .ifPresent(deviceToken -> deviceToken.deactivate(UNREGISTERED_REASON)));
+    }
+
+    private void validate(UpsertFcmDeviceTokenCommand command) {
+        if (command.token() == null || command.token().isBlank()) {
+            throw new AppException(ErrorType.INVALID_FCM_DEVICE_TOKEN);
+        }
+        if (command.memberKey() == null || command.memberKey().isBlank() || command.recipientType() == null) {
+            throw new AppException(ErrorType.INVALID_FCM_DEVICE_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/recaring/notification/implement/FcmDeviceTokenReader.java
+++ b/src/main/java/com/recaring/notification/implement/FcmDeviceTokenReader.java
@@ -1,0 +1,43 @@
+package com.recaring.notification.implement;
+
+import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
+import com.recaring.notification.dataaccess.entity.NotificationRecipientType;
+import com.recaring.notification.dataaccess.repository.FcmDeviceTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class FcmDeviceTokenReader {
+
+    private final FcmDeviceTokenRepository fcmDeviceTokenRepository;
+
+    public List<FcmDeviceToken> findActiveRecipientTokens(
+            Collection<String> guardianMemberKeys,
+            Collection<String> managerMemberKeys
+    ) {
+        List<FcmDeviceToken> tokens = new ArrayList<>();
+        if (guardianMemberKeys != null && !guardianMemberKeys.isEmpty()) {
+            tokens.addAll(fcmDeviceTokenRepository.findAllByMemberKeyInAndRecipientTypeAndActiveTrue(
+                    guardianMemberKeys,
+                    NotificationRecipientType.GUARDIAN
+            ));
+        }
+        if (managerMemberKeys != null && !managerMemberKeys.isEmpty()) {
+            tokens.addAll(fcmDeviceTokenRepository.findAllByMemberKeyInAndRecipientTypeAndActiveTrue(
+                    managerMemberKeys,
+                    NotificationRecipientType.MANAGER
+            ));
+        }
+
+        Map<String, FcmDeviceToken> deduplicated = new LinkedHashMap<>();
+        tokens.forEach(token -> deduplicated.putIfAbsent(token.getToken(), token));
+        return List.copyOf(deduplicated.values());
+    }
+}

--- a/src/main/java/com/recaring/notification/implement/FcmPushMessage.java
+++ b/src/main/java/com/recaring/notification/implement/FcmPushMessage.java
@@ -1,0 +1,10 @@
+package com.recaring.notification.implement;
+
+import java.util.Map;
+
+public record FcmPushMessage(
+        String title,
+        String body,
+        Map<String, String> dataPayload
+) {
+}

--- a/src/main/java/com/recaring/notification/implement/FcmSendResult.java
+++ b/src/main/java/com/recaring/notification/implement/FcmSendResult.java
@@ -1,0 +1,14 @@
+package com.recaring.notification.implement;
+
+import java.util.List;
+
+public record FcmSendResult(
+        List<FcmTokenSendResult> tokenResults
+) {
+    public List<String> invalidTokens() {
+        return tokenResults.stream()
+                .filter(FcmTokenSendResult::invalidToken)
+                .map(FcmTokenSendResult::token)
+                .toList();
+    }
+}

--- a/src/main/java/com/recaring/notification/implement/FcmTokenSendResult.java
+++ b/src/main/java/com/recaring/notification/implement/FcmTokenSendResult.java
@@ -1,0 +1,26 @@
+package com.recaring.notification.implement;
+
+public record FcmTokenSendResult(
+        String token,
+        boolean success,
+        String messageId,
+        String errorCode,
+        String errorMessage,
+        boolean retryable,
+        boolean invalidToken,
+        int attemptCount
+) {
+    public static FcmTokenSendResult sent(String token, String messageId) {
+        return new FcmTokenSendResult(token, true, messageId, null, null, false, false, 1);
+    }
+
+    public static FcmTokenSendResult failed(
+            String token,
+            String errorCode,
+            String errorMessage,
+            boolean retryable,
+            boolean invalidToken
+    ) {
+        return new FcmTokenSendResult(token, false, null, errorCode, errorMessage, retryable, invalidToken, 1);
+    }
+}

--- a/src/main/java/com/recaring/notification/implement/FirebaseFcmClient.java
+++ b/src/main/java/com/recaring/notification/implement/FirebaseFcmClient.java
@@ -1,0 +1,117 @@
+package com.recaring.notification.implement;
+
+import com.google.firebase.ErrorCode;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.SendResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnBean(FirebaseMessaging.class)
+public class FirebaseFcmClient implements FcmClient {
+
+    private static final int MULTICAST_LIMIT = 500;
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    @Override
+    public FcmSendResult send(FcmPushMessage message, List<String> tokens) {
+        List<FcmTokenSendResult> results = new ArrayList<>();
+        for (int start = 0; start < tokens.size(); start += MULTICAST_LIMIT) {
+            int end = Math.min(start + MULTICAST_LIMIT, tokens.size());
+            results.addAll(sendBatch(message, tokens.subList(start, end)));
+        }
+        return new FcmSendResult(results);
+    }
+
+    private List<FcmTokenSendResult> sendBatch(FcmPushMessage message, List<String> tokens) {
+        MulticastMessage multicastMessage = MulticastMessage.builder()
+                .setNotification(com.google.firebase.messaging.Notification.builder()
+                        .setTitle(message.title())
+                        .setBody(message.body())
+                        .build())
+                .putAllData(message.dataPayload())
+                .addAllTokens(tokens)
+                .build();
+
+        try {
+            BatchResponse response = firebaseMessaging.sendEachForMulticast(multicastMessage);
+            return parseBatchResponse(tokens, response);
+        } catch (FirebaseMessagingException exception) {
+            return tokens.stream()
+                    .map(token -> FcmTokenSendResult.failed(
+                            token,
+                            errorCode(exception),
+                            exception.getMessage(),
+                            isRetryable(exception),
+                            isInvalidToken(exception)
+                    ))
+                    .toList();
+        } catch (RuntimeException exception) {
+            return tokens.stream()
+                    .map(token -> FcmTokenSendResult.failed(
+                            token,
+                            "FCM_SEND_EXCEPTION",
+                            exception.getMessage(),
+                            true,
+                            false
+                    ))
+                    .toList();
+        }
+    }
+
+    private List<FcmTokenSendResult> parseBatchResponse(List<String> tokens, BatchResponse response) {
+        List<FcmTokenSendResult> results = new ArrayList<>();
+        List<SendResponse> responses = response.getResponses();
+        for (int index = 0; index < responses.size(); index++) {
+            SendResponse sendResponse = responses.get(index);
+            String token = tokens.get(index);
+            if (sendResponse.isSuccessful()) {
+                results.add(FcmTokenSendResult.sent(token, sendResponse.getMessageId()));
+                continue;
+            }
+
+            FirebaseMessagingException exception = sendResponse.getException();
+            results.add(FcmTokenSendResult.failed(
+                    token,
+                    errorCode(exception),
+                    exception.getMessage(),
+                    isRetryable(exception),
+                    isInvalidToken(exception)
+            ));
+        }
+        return results;
+    }
+
+    private String errorCode(FirebaseMessagingException exception) {
+        MessagingErrorCode messagingErrorCode = exception.getMessagingErrorCode();
+        if (messagingErrorCode != null) {
+            return messagingErrorCode.name();
+        }
+
+        ErrorCode errorCode = exception.getErrorCode();
+        return errorCode == null ? "UNKNOWN" : errorCode.name();
+    }
+
+    private boolean isInvalidToken(FirebaseMessagingException exception) {
+        MessagingErrorCode code = exception.getMessagingErrorCode();
+        return code == MessagingErrorCode.UNREGISTERED || code == MessagingErrorCode.INVALID_ARGUMENT;
+    }
+
+    private boolean isRetryable(FirebaseMessagingException exception) {
+        if (isInvalidToken(exception)) {
+            return false;
+        }
+        ErrorCode code = exception.getErrorCode();
+        return code == ErrorCode.UNAVAILABLE || code == ErrorCode.INTERNAL || code == ErrorCode.DEADLINE_EXCEEDED;
+    }
+}

--- a/src/main/java/com/recaring/notification/implement/NoOpFcmClient.java
+++ b/src/main/java/com/recaring/notification/implement/NoOpFcmClient.java
@@ -1,0 +1,19 @@
+package com.recaring.notification.implement;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@ConditionalOnProperty(prefix = "firebase", name = "enabled", havingValue = "false", matchIfMissing = true)
+public class NoOpFcmClient implements FcmClient {
+
+    @Override
+    public FcmSendResult send(FcmPushMessage message, List<String> tokens) {
+        List<FcmTokenSendResult> results = tokens.stream()
+                .map(token -> FcmTokenSendResult.sent(token, "noop:" + token))
+                .toList();
+        return new FcmSendResult(results);
+    }
+}

--- a/src/main/java/com/recaring/notification/implement/NotificationDeliveryManager.java
+++ b/src/main/java/com/recaring/notification/implement/NotificationDeliveryManager.java
@@ -1,0 +1,73 @@
+package com.recaring.notification.implement;
+
+import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
+import com.recaring.notification.dataaccess.entity.Notification;
+import com.recaring.notification.dataaccess.entity.NotificationDelivery;
+import com.recaring.notification.dataaccess.entity.NotificationDeliveryStatus;
+import com.recaring.notification.dataaccess.repository.NotificationDeliveryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationDeliveryManager {
+
+    private static final int RETRY_DELAY_MINUTES = 5;
+
+    private final NotificationDeliveryRepository notificationDeliveryRepository;
+
+    @Transactional
+    public List<NotificationDelivery> addRequested(Notification notification, List<FcmDeviceToken> tokens) {
+        List<NotificationDelivery> deliveries = tokens.stream()
+                .map(token -> NotificationDelivery.requested(notification, token))
+                .toList();
+        return notificationDeliveryRepository.saveAll(deliveries);
+    }
+
+    @Transactional
+    public void applyResults(List<NotificationDelivery> deliveries, FcmSendResult sendResult) {
+        Map<String, FcmTokenSendResult> resultByToken = sendResult.tokenResults().stream()
+                .collect(Collectors.toMap(
+                        FcmTokenSendResult::token,
+                        Function.identity(),
+                        (left, right) -> left
+                ));
+
+        deliveries.forEach(delivery -> {
+            FcmTokenSendResult result = resultByToken.get(delivery.getTokenSnapshot());
+            if (result == null) {
+                delivery.markFailed("MISSING_FCM_RESULT", "FCM result was not returned.", 1, true, nextRetryAt());
+                return;
+            }
+            if (result.success()) {
+                delivery.markSent(result.messageId(), result.attemptCount());
+                return;
+            }
+            delivery.markFailed(
+                    result.errorCode(),
+                    result.errorMessage(),
+                    result.attemptCount(),
+                    result.retryable(),
+                    result.retryable() ? nextRetryAt() : null
+            );
+        });
+    }
+
+    public List<NotificationDelivery> findRetryTargets(LocalDateTime now) {
+        return notificationDeliveryRepository.findAllByStatusAndRetryableTrueAndNextRetryAtLessThanEqual(
+                NotificationDeliveryStatus.FAILED,
+                now
+        );
+    }
+
+    private LocalDateTime nextRetryAt() {
+        return LocalDateTime.now().plusMinutes(RETRY_DELAY_MINUTES);
+    }
+}

--- a/src/main/java/com/recaring/notification/implement/NotificationDeliveryManager.java
+++ b/src/main/java/com/recaring/notification/implement/NotificationDeliveryManager.java
@@ -43,7 +43,13 @@ public class NotificationDeliveryManager {
         deliveries.forEach(delivery -> {
             FcmTokenSendResult result = resultByToken.get(delivery.getTokenSnapshot());
             if (result == null) {
-                delivery.markFailed("MISSING_FCM_RESULT", "FCM result was not returned.", 1, true, nextRetryAt());
+                delivery.markFailed(
+                        "MISSING_FCM_RESULT",
+                        "FCM result was not returned.",
+                        delivery.getAttemptCount() + 1,
+                        true,
+                        nextRetryAt()
+                );
                 return;
             }
             if (result.success()) {
@@ -58,6 +64,7 @@ public class NotificationDeliveryManager {
                     result.retryable() ? nextRetryAt() : null
             );
         });
+        notificationDeliveryRepository.saveAll(deliveries);
     }
 
     public List<NotificationDelivery> findRetryTargets(LocalDateTime now) {

--- a/src/main/java/com/recaring/notification/implement/NotificationPayloadSerializer.java
+++ b/src/main/java/com/recaring/notification/implement/NotificationPayloadSerializer.java
@@ -1,0 +1,26 @@
+package com.recaring.notification.implement;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationPayloadSerializer {
+
+    private final ObjectMapper objectMapper;
+
+    public String serialize(Object payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException exception) {
+            log.error("[알림] payload 직렬화 실패", exception);
+            throw new AppException(ErrorType.NOTIFICATION_PAYLOAD_SERIALIZATION_FAILED, exception);
+        }
+    }
+}

--- a/src/main/java/com/recaring/notification/implement/NotificationWriter.java
+++ b/src/main/java/com/recaring/notification/implement/NotificationWriter.java
@@ -32,6 +32,7 @@ public class NotificationWriter {
     @Transactional
     public void markFailedForNoActiveToken(Notification notification) {
         notification.markFailed(NO_ACTIVE_TOKEN, "No active FCM device token was found.");
+        notificationRepository.save(notification);
     }
 
     @Transactional
@@ -45,12 +46,15 @@ public class NotificationWriter {
 
         if (sentCount > 0 && failedCount == 0) {
             notification.markSent();
+            notificationRepository.save(notification);
             return;
         }
         if (sentCount > 0) {
             notification.markPartial(DELIVERY_FAILED, failedCount + " deliveries failed.");
+            notificationRepository.save(notification);
             return;
         }
         notification.markFailed(DELIVERY_FAILED, "All deliveries failed.");
+        notificationRepository.save(notification);
     }
 }

--- a/src/main/java/com/recaring/notification/implement/NotificationWriter.java
+++ b/src/main/java/com/recaring/notification/implement/NotificationWriter.java
@@ -1,0 +1,56 @@
+package com.recaring.notification.implement;
+
+import com.recaring.notification.dataaccess.entity.Notification;
+import com.recaring.notification.dataaccess.entity.NotificationDelivery;
+import com.recaring.notification.dataaccess.entity.NotificationDeliveryStatus;
+import com.recaring.notification.dataaccess.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationWriter {
+
+    private static final String NO_ACTIVE_TOKEN = "NO_ACTIVE_TOKEN";
+    private static final String DELIVERY_FAILED = "DELIVERY_FAILED";
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    public Notification addRequested(String eventType, String title, String body, String dataPayload) {
+        return notificationRepository.save(Notification.builder()
+                .eventType(eventType)
+                .title(title)
+                .body(body)
+                .dataPayload(dataPayload)
+                .build());
+    }
+
+    @Transactional
+    public void markFailedForNoActiveToken(Notification notification) {
+        notification.markFailed(NO_ACTIVE_TOKEN, "No active FCM device token was found.");
+    }
+
+    @Transactional
+    public void completeByDeliveries(Notification notification, List<NotificationDelivery> deliveries) {
+        long sentCount = deliveries.stream()
+                .filter(delivery -> delivery.getStatus() == NotificationDeliveryStatus.SENT)
+                .count();
+        long failedCount = deliveries.stream()
+                .filter(delivery -> delivery.getStatus() == NotificationDeliveryStatus.FAILED)
+                .count();
+
+        if (sentCount > 0 && failedCount == 0) {
+            notification.markSent();
+            return;
+        }
+        if (sentCount > 0) {
+            notification.markPartial(DELIVERY_FAILED, failedCount + " deliveries failed.");
+            return;
+        }
+        notification.markFailed(DELIVERY_FAILED, "All deliveries failed.");
+    }
+}

--- a/src/main/java/com/recaring/support/exception/AppException.java
+++ b/src/main/java/com/recaring/support/exception/AppException.java
@@ -19,4 +19,10 @@ public class AppException extends RuntimeException{
         this.errorType = errorType;
         this.data = data;
     }
+
+    public AppException(ErrorType errorType, Throwable cause) {
+        super(errorType.getMessage(), cause);
+        this.errorType = errorType;
+        this.data = null;
+    }
 }

--- a/src/main/java/com/recaring/support/exception/ErrorCode.java
+++ b/src/main/java/com/recaring/support/exception/ErrorCode.java
@@ -29,6 +29,6 @@ public enum ErrorCode {
     E8000, E8001,
 
     // Notification (E9xxx)
-    E9000, E9001, E9002
+    E9000, E9001, E9002, E9003, E9004
 
 }

--- a/src/main/java/com/recaring/support/exception/ErrorType.java
+++ b/src/main/java/com/recaring/support/exception/ErrorType.java
@@ -81,7 +81,9 @@ public enum ErrorType {
     // Notification (E9xxx)
     INVALID_NOTIFICATION_SENSITIVITY(HttpStatus.BAD_REQUEST, ErrorCode.E9000, "Unsupported notification sensitivity.", LogLevel.WARN),
     INVALID_BATTERY_THRESHOLD(HttpStatus.BAD_REQUEST, ErrorCode.E9001, "Unsupported battery threshold.", LogLevel.WARN),
-    NOTIFICATION_SETTING_UPDATE_CONFLICT(HttpStatus.CONFLICT, ErrorCode.E9002, "Notification setting was updated by another request. Please retry.", LogLevel.WARN);
+    NOTIFICATION_SETTING_UPDATE_CONFLICT(HttpStatus.CONFLICT, ErrorCode.E9002, "Notification setting was updated by another request. Please retry.", LogLevel.WARN),
+    INVALID_FCM_DEVICE_TOKEN(HttpStatus.BAD_REQUEST, ErrorCode.E9003, "Invalid FCM device token.", LogLevel.WARN),
+    NOTIFICATION_PAYLOAD_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E9004, "Notification payload serialization failed.", LogLevel.ERROR);
 
     private final HttpStatus status;
     private final ErrorCode errorCode;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,7 @@ logging:
   level:
     root: INFO
 
+firebase:
+  enabled: ${FIREBASE_ENABLED:false}
+  service-account-json-base64: ${FIREBASE_SERVICE_ACCOUNT_JSON_BASE64:}
+

--- a/src/test/java/com/recaring/config/infra/FirebaseConfigTest.java
+++ b/src/test/java/com/recaring/config/infra/FirebaseConfigTest.java
@@ -1,0 +1,25 @@
+package com.recaring.config.infra;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Firebase 설정 단위 테스트")
+class FirebaseConfigTest {
+
+    @Test
+    @DisplayName("서비스 계정 값이 Base64 형식이 아니면 설정 오류를 명확히 던진다")
+    void firebaseApp_throws_clear_exception_when_service_account_is_not_base64() {
+        FirebaseConfig firebaseConfig = new FirebaseConfig();
+        ReflectionTestUtils.setField(firebaseConfig, "serviceAccountJsonBase64", "not-base64!");
+
+        assertThatThrownBy(firebaseConfig::firebaseApp)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("firebase.service-account-json-base64 must be valid Base64 encoded JSON.")
+                .satisfies(exception -> assertThat(exception.getCause())
+                        .isInstanceOf(IllegalArgumentException.class));
+    }
+}

--- a/src/test/java/com/recaring/notification/business/NotificationSendServiceTest.java
+++ b/src/test/java/com/recaring/notification/business/NotificationSendServiceTest.java
@@ -1,0 +1,127 @@
+package com.recaring.notification.business;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.recaring.notification.business.command.NotificationSendCommand;
+import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
+import com.recaring.notification.dataaccess.entity.Notification;
+import com.recaring.notification.dataaccess.entity.NotificationDelivery;
+import com.recaring.notification.dataaccess.entity.NotificationStatus;
+import com.recaring.notification.fixture.NotificationFixture;
+import com.recaring.notification.implement.FcmClient;
+import com.recaring.notification.implement.FcmDeviceTokenManager;
+import com.recaring.notification.implement.FcmDeviceTokenReader;
+import com.recaring.notification.implement.FcmSendResult;
+import com.recaring.notification.implement.FcmTokenSendResult;
+import com.recaring.notification.implement.NotificationDeliveryManager;
+import com.recaring.notification.implement.NotificationWriter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotificationSendService unit test")
+class NotificationSendServiceTest {
+
+    @InjectMocks
+    private NotificationSendService notificationSendService;
+
+    @Mock
+    private FcmDeviceTokenReader fcmDeviceTokenReader;
+    @Mock
+    private FcmDeviceTokenManager fcmDeviceTokenManager;
+    @Mock
+    private NotificationWriter notificationWriter;
+    @Mock
+    private NotificationDeliveryManager notificationDeliveryManager;
+    @Mock
+    private FcmClient fcmClient;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("Sends FCM and stores delivery results")
+    void send_sends_fcm_and_records_results() {
+        notificationSendService = new NotificationSendService(
+                objectMapper,
+                fcmDeviceTokenReader,
+                fcmDeviceTokenManager,
+                notificationWriter,
+                notificationDeliveryManager,
+                fcmClient
+        );
+        NotificationSendCommand command = NotificationFixture.sendCommand();
+        Notification notification = Notification.builder()
+                .eventType(command.eventType())
+                .title(command.title())
+                .body(command.body())
+                .dataPayload("{\"wardKey\":\"ward-member-key-001\"}")
+                .build();
+        FcmDeviceToken guardianToken =
+                NotificationFixture.guardianFcmDeviceToken(NotificationFixture.GUARDIAN_FCM_TOKEN);
+        FcmDeviceToken managerToken =
+                NotificationFixture.managerFcmDeviceToken(NotificationFixture.MANAGER_FCM_TOKEN);
+        List<FcmDeviceToken> tokens = List.of(guardianToken, managerToken);
+        List<NotificationDelivery> deliveries = tokens.stream()
+                .map(token -> NotificationDelivery.requested(notification, token))
+                .toList();
+        FcmSendResult sendResult = new FcmSendResult(List.of(
+                FcmTokenSendResult.sent(NotificationFixture.GUARDIAN_FCM_TOKEN, "message-id"),
+                FcmTokenSendResult.failed(NotificationFixture.MANAGER_FCM_TOKEN, "UNAVAILABLE", "temporary", true, false)
+        ));
+
+        given(notificationWriter.addRequested(any(), any(), any(), any())).willReturn(notification);
+        given(fcmDeviceTokenReader.findActiveRecipientTokens(command.guardianMemberKeys(), command.managerMemberKeys()))
+                .willReturn(tokens);
+        given(notificationDeliveryManager.addRequested(notification, tokens)).willReturn(deliveries);
+        given(fcmClient.send(any(), any())).willReturn(sendResult);
+
+        NotificationSendResult result = notificationSendService.send(command);
+
+        then(notificationDeliveryManager).should().applyResults(deliveries, sendResult);
+        then(fcmDeviceTokenManager).should().deactivateInvalidTokens(List.of());
+        then(notificationWriter).should().completeByDeliveries(notification, deliveries);
+        assertThat(result.notificationKey()).isEqualTo(notification.getNotificationKey());
+    }
+
+    @Test
+    @DisplayName("Marks notification failed when active tokens are absent")
+    void send_marks_failed_when_no_tokens() {
+        notificationSendService = new NotificationSendService(
+                objectMapper,
+                fcmDeviceTokenReader,
+                fcmDeviceTokenManager,
+                notificationWriter,
+                notificationDeliveryManager,
+                fcmClient
+        );
+        NotificationSendCommand command = NotificationFixture.sendCommand();
+        Notification notification = Notification.builder()
+                .eventType(command.eventType())
+                .title(command.title())
+                .body(command.body())
+                .dataPayload("{}")
+                .build();
+        notification.markFailed("NO_ACTIVE_TOKEN", "No active FCM device token was found.");
+
+        given(notificationWriter.addRequested(any(), any(), any(), any())).willReturn(notification);
+        given(fcmDeviceTokenReader.findActiveRecipientTokens(command.guardianMemberKeys(), command.managerMemberKeys()))
+                .willReturn(List.of());
+
+        NotificationSendResult result = notificationSendService.send(command);
+
+        then(notificationWriter).should().markFailedForNoActiveToken(notification);
+        then(fcmClient).shouldHaveNoInteractions();
+        assertThat(result.status()).isEqualTo(NotificationStatus.FAILED);
+        assertThat(result.requestedCount()).isZero();
+    }
+}

--- a/src/test/java/com/recaring/notification/business/NotificationSendServiceTest.java
+++ b/src/test/java/com/recaring/notification/business/NotificationSendServiceTest.java
@@ -1,6 +1,5 @@
 package com.recaring.notification.business;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.recaring.notification.business.command.NotificationSendCommand;
 import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
 import com.recaring.notification.dataaccess.entity.Notification;
@@ -13,6 +12,7 @@ import com.recaring.notification.implement.FcmDeviceTokenReader;
 import com.recaring.notification.implement.FcmSendResult;
 import com.recaring.notification.implement.FcmTokenSendResult;
 import com.recaring.notification.implement.NotificationDeliveryManager;
+import com.recaring.notification.implement.NotificationPayloadSerializer;
 import com.recaring.notification.implement.NotificationWriter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,12 +29,14 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("NotificationSendService unit test")
+@DisplayName("알림 발송 서비스 단위 테스트")
 class NotificationSendServiceTest {
 
     @InjectMocks
     private NotificationSendService notificationSendService;
 
+    @Mock
+    private NotificationPayloadSerializer notificationPayloadSerializer;
     @Mock
     private FcmDeviceTokenReader fcmDeviceTokenReader;
     @Mock
@@ -46,19 +48,9 @@ class NotificationSendServiceTest {
     @Mock
     private FcmClient fcmClient;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     @Test
-    @DisplayName("Sends FCM and stores delivery results")
+    @DisplayName("FCM을 발송하고 전달 결과를 저장한다")
     void send_sends_fcm_and_records_results() {
-        notificationSendService = new NotificationSendService(
-                objectMapper,
-                fcmDeviceTokenReader,
-                fcmDeviceTokenManager,
-                notificationWriter,
-                notificationDeliveryManager,
-                fcmClient
-        );
         NotificationSendCommand command = NotificationFixture.sendCommand();
         Notification notification = Notification.builder()
                 .eventType(command.eventType())
@@ -79,6 +71,8 @@ class NotificationSendServiceTest {
                 FcmTokenSendResult.failed(NotificationFixture.MANAGER_FCM_TOKEN, "UNAVAILABLE", "temporary", true, false)
         ));
 
+        given(notificationPayloadSerializer.serialize(command.dataPayload()))
+                .willReturn("{\"wardKey\":\"ward-member-key-001\"}");
         given(notificationWriter.addRequested(any(), any(), any(), any())).willReturn(notification);
         given(fcmDeviceTokenReader.findActiveRecipientTokens(command.guardianMemberKeys(), command.managerMemberKeys()))
                 .willReturn(tokens);
@@ -89,21 +83,17 @@ class NotificationSendServiceTest {
 
         then(notificationDeliveryManager).should().applyResults(deliveries, sendResult);
         then(fcmDeviceTokenManager).should().deactivateInvalidTokens(List.of());
+        then(fcmDeviceTokenManager).should().touchLastUsedAt(List.of(
+                NotificationFixture.GUARDIAN_FCM_TOKEN,
+                NotificationFixture.MANAGER_FCM_TOKEN
+        ));
         then(notificationWriter).should().completeByDeliveries(notification, deliveries);
         assertThat(result.notificationKey()).isEqualTo(notification.getNotificationKey());
     }
 
     @Test
-    @DisplayName("Marks notification failed when active tokens are absent")
+    @DisplayName("활성 토큰이 없으면 알림을 실패로 처리한다")
     void send_marks_failed_when_no_tokens() {
-        notificationSendService = new NotificationSendService(
-                objectMapper,
-                fcmDeviceTokenReader,
-                fcmDeviceTokenManager,
-                notificationWriter,
-                notificationDeliveryManager,
-                fcmClient
-        );
         NotificationSendCommand command = NotificationFixture.sendCommand();
         Notification notification = Notification.builder()
                 .eventType(command.eventType())
@@ -113,6 +103,7 @@ class NotificationSendServiceTest {
                 .build();
         notification.markFailed("NO_ACTIVE_TOKEN", "No active FCM device token was found.");
 
+        given(notificationPayloadSerializer.serialize(command.dataPayload())).willReturn("{}");
         given(notificationWriter.addRequested(any(), any(), any(), any())).willReturn(notification);
         given(fcmDeviceTokenReader.findActiveRecipientTokens(command.guardianMemberKeys(), command.managerMemberKeys()))
                 .willReturn(List.of());

--- a/src/test/java/com/recaring/notification/controller/FcmDeviceTokenControllerTest.java
+++ b/src/test/java/com/recaring/notification/controller/FcmDeviceTokenControllerTest.java
@@ -1,0 +1,166 @@
+package com.recaring.notification.controller;
+
+import com.recaring.member.dataaccess.entity.Member;
+import com.recaring.member.dataaccess.repository.MemberRepository;
+import com.recaring.notification.dataaccess.repository.FcmDeviceTokenRepository;
+import com.recaring.notification.fixture.NotificationFixture;
+import com.recaring.security.jwt.JwtGenerator;
+import com.recaring.security.vo.TokenPayload;
+import com.recaring.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("FcmDeviceTokenController HTTP integration test")
+@Tag("integration")
+class FcmDeviceTokenControllerTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private FcmDeviceTokenRepository fcmDeviceTokenRepository;
+    @Autowired
+    private JwtGenerator jwtGenerator;
+
+    private Member guardian;
+    private Member manager;
+    private Member ward;
+
+    @BeforeEach
+    void setUp() {
+        guardian = memberRepository.save(NotificationFixture.createGuardian());
+        manager = memberRepository.save(NotificationFixture.createManager());
+        ward = memberRepository.save(NotificationFixture.createWard());
+    }
+
+    @AfterEach
+    void tearDown() {
+        fcmDeviceTokenRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/notifications/device-tokens - guardian token is registered")
+    void upsert_registers_guardian_token() {
+        client.put()
+                .uri("/api/v1/notifications/device-tokens")
+                .header(HttpHeaders.AUTHORIZATION, bearerToken(guardian))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {
+                          "token": "guardian-fcm-token-http",
+                          "recipientType": "GUARDIAN",
+                          "platform": "ANDROID"
+                        }
+                        """)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.resultType").isEqualTo("SUCCESS")
+                .jsonPath("$.data.memberKey").isEqualTo(guardian.getMemberKey())
+                .jsonPath("$.data.recipientType").isEqualTo("GUARDIAN")
+                .jsonPath("$.data.platform").isEqualTo("ANDROID")
+                .jsonPath("$.data.active").isEqualTo(true);
+
+        assertThat(fcmDeviceTokenRepository.findByToken("guardian-fcm-token-http"))
+                .isPresent()
+                .get()
+                .satisfies(token -> {
+                    assertThat(token.getMemberKey()).isEqualTo(guardian.getMemberKey());
+                    assertThat(token.isActive()).isTrue();
+                });
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/notifications/device-tokens - existing token is reassigned")
+    void upsert_reassigns_existing_token() {
+        client.put()
+                .uri("/api/v1/notifications/device-tokens")
+                .header(HttpHeaders.AUTHORIZATION, bearerToken(guardian))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {
+                          "token": "shared-fcm-token-http",
+                          "recipientType": "GUARDIAN",
+                          "platform": "ANDROID"
+                        }
+                        """)
+                .exchange()
+                .expectStatus().isOk();
+
+        client.put()
+                .uri("/api/v1/notifications/device-tokens")
+                .header(HttpHeaders.AUTHORIZATION, bearerToken(manager))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {
+                          "token": "shared-fcm-token-http",
+                          "recipientType": "MANAGER",
+                          "platform": "IOS"
+                        }
+                        """)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.data.memberKey").isEqualTo(manager.getMemberKey())
+                .jsonPath("$.data.recipientType").isEqualTo("MANAGER")
+                .jsonPath("$.data.platform").isEqualTo("IOS");
+
+        assertThat(fcmDeviceTokenRepository.findAll()).hasSize(1);
+        assertThat(fcmDeviceTokenRepository.findByToken("shared-fcm-token-http"))
+                .isPresent()
+                .get()
+                .satisfies(token -> assertThat(token.getMemberKey()).isEqualTo(manager.getMemberKey()));
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/notifications/device-tokens - ward cannot register FCM recipient token")
+    void upsert_returns_401_for_ward() {
+        client.put()
+                .uri("/api/v1/notifications/device-tokens")
+                .header(HttpHeaders.AUTHORIZATION, bearerToken(ward))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {
+                          "token": "ward-fcm-token-http",
+                          "recipientType": "GUARDIAN",
+                          "platform": "ANDROID"
+                        }
+                        """)
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/notifications/device-tokens - blank token returns 400")
+    void upsert_returns_400_for_blank_token() {
+        client.put()
+                .uri("/api/v1/notifications/device-tokens")
+                .header(HttpHeaders.AUTHORIZATION, bearerToken(guardian))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("""
+                        {
+                          "token": " ",
+                          "recipientType": "GUARDIAN",
+                          "platform": "ANDROID"
+                        }
+                        """)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    private String bearerToken(Member member) {
+        return "Bearer " + jwtGenerator.generateJwt(
+                new TokenPayload(member.getMemberKey(), member.getRole(), new Date())
+        ).accessToken();
+    }
+}

--- a/src/test/java/com/recaring/notification/controller/FcmDeviceTokenControllerTest.java
+++ b/src/test/java/com/recaring/notification/controller/FcmDeviceTokenControllerTest.java
@@ -20,7 +20,7 @@ import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("FcmDeviceTokenController HTTP integration test")
+@DisplayName("FCM 디바이스 토큰 컨트롤러 HTTP 통합 테스트")
 @Tag("integration")
 class FcmDeviceTokenControllerTest extends AbstractIntegrationTest {
 
@@ -49,7 +49,7 @@ class FcmDeviceTokenControllerTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("PUT /api/v1/notifications/device-tokens - guardian token is registered")
+    @DisplayName("보호자 FCM 토큰을 등록한다")
     void upsert_registers_guardian_token() {
         client.put()
                 .uri("/api/v1/notifications/device-tokens")
@@ -81,7 +81,7 @@ class FcmDeviceTokenControllerTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("PUT /api/v1/notifications/device-tokens - existing token is reassigned")
+    @DisplayName("기존 FCM 토큰을 다른 수신자에게 재할당한다")
     void upsert_reassigns_existing_token() {
         client.put()
                 .uri("/api/v1/notifications/device-tokens")
@@ -123,7 +123,7 @@ class FcmDeviceTokenControllerTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("PUT /api/v1/notifications/device-tokens - ward cannot register FCM recipient token")
+    @DisplayName("피보호자는 FCM 수신자 토큰을 등록할 수 없다")
     void upsert_returns_401_for_ward() {
         client.put()
                 .uri("/api/v1/notifications/device-tokens")
@@ -141,7 +141,7 @@ class FcmDeviceTokenControllerTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("PUT /api/v1/notifications/device-tokens - blank token returns 400")
+    @DisplayName("빈 FCM 토큰이면 400을 반환한다")
     void upsert_returns_400_for_blank_token() {
         client.put()
                 .uri("/api/v1/notifications/device-tokens")

--- a/src/test/java/com/recaring/notification/controller/NotificationSettingControllerTest.java
+++ b/src/test/java/com/recaring/notification/controller/NotificationSettingControllerTest.java
@@ -259,7 +259,9 @@ class NotificationSettingControllerTest extends AbstractIntegrationTest {
                 .jsonPath("$.paths['/api/v1/notifications/settings/{wardKey}/emergency-call'].patch.summary")
                 .isEqualTo("Update emergency call notification settings")
                 .jsonPath("$.paths['/api/v1/notifications/settings/{wardKey}/battery'].patch.summary")
-                .isEqualTo("Update battery notification settings");
+                .isEqualTo("Update battery notification settings")
+                .jsonPath("$.paths['/api/v1/notifications/device-tokens'].put.summary")
+                .isEqualTo("Upsert FCM device token");
     }
 
     @Test

--- a/src/test/java/com/recaring/notification/controller/NotificationSettingSwaggerHttpTest.java
+++ b/src/test/java/com/recaring/notification/controller/NotificationSettingSwaggerHttpTest.java
@@ -74,6 +74,8 @@ class NotificationSettingSwaggerHttpTest {
         assertThat(response.body()).contains("\"summary\":\"Update emergency call notification settings\"");
         assertThat(response.body()).contains("\"/api/v1/notifications/settings/{wardKey}/battery\"");
         assertThat(response.body()).contains("\"summary\":\"Update battery notification settings\"");
+        assertThat(response.body()).contains("\"/api/v1/notifications/device-tokens\"");
+        assertThat(response.body()).contains("\"summary\":\"Upsert FCM device token\"");
     }
 
     @Test
@@ -97,6 +99,7 @@ class NotificationSettingSwaggerHttpTest {
     @EnableAutoConfiguration
     @Import({
             NotificationSettingController.class,
+            FcmDeviceTokenController.class,
             SwaggerConfig.class
     })
     @ImportAutoConfiguration(classes = {
@@ -113,6 +116,11 @@ class NotificationSettingSwaggerHttpTest {
         @Bean
         NotificationSettingService notificationSettingService() {
             return Mockito.mock(NotificationSettingService.class);
+        }
+
+        @Bean
+        com.recaring.notification.business.FcmDeviceTokenService fcmDeviceTokenService() {
+            return Mockito.mock(com.recaring.notification.business.FcmDeviceTokenService.class);
         }
     }
 }

--- a/src/test/java/com/recaring/notification/fixture/NotificationFixture.java
+++ b/src/test/java/com/recaring/notification/fixture/NotificationFixture.java
@@ -4,10 +4,17 @@ import com.recaring.member.dataaccess.entity.Gender;
 import com.recaring.member.dataaccess.entity.Member;
 import com.recaring.member.dataaccess.entity.MemberRole;
 import com.recaring.member.dataaccess.entity.SignUpType;
+import com.recaring.notification.business.command.NotificationSendCommand;
+import com.recaring.notification.business.command.UpsertFcmDeviceTokenCommand;
+import com.recaring.notification.dataaccess.entity.FcmDevicePlatform;
+import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
 import com.recaring.notification.dataaccess.entity.NotificationSetting;
+import com.recaring.notification.dataaccess.entity.NotificationRecipientType;
 import com.recaring.notification.vo.AnomalySensitivity;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 
 public class NotificationFixture {
 
@@ -15,6 +22,8 @@ public class NotificationFixture {
     public static final String GUARDIAN_KEY = "guardian-member-key-001";
     public static final String MANAGER_KEY = "manager-member-key-001";
     public static final String OTHER_GUARDIAN_KEY = "other-guardian-member-key-001";
+    public static final String GUARDIAN_FCM_TOKEN = "guardian-fcm-token-001";
+    public static final String MANAGER_FCM_TOKEN = "manager-fcm-token-001";
 
     public static Member createWard() {
         return Member.builder()
@@ -74,5 +83,43 @@ public class NotificationFixture {
                 .lowBatteryEnabled(false)
                 .batteryThresholdPercent(40)
                 .build();
+    }
+
+    public static UpsertFcmDeviceTokenCommand guardianTokenCommand(String token) {
+        return new UpsertFcmDeviceTokenCommand(
+                GUARDIAN_KEY,
+                NotificationRecipientType.GUARDIAN,
+                token,
+                FcmDevicePlatform.ANDROID
+        );
+    }
+
+    public static FcmDeviceToken guardianFcmDeviceToken(String token) {
+        return FcmDeviceToken.builder()
+                .memberKey(GUARDIAN_KEY)
+                .recipientType(NotificationRecipientType.GUARDIAN)
+                .token(token)
+                .platform(FcmDevicePlatform.ANDROID)
+                .build();
+    }
+
+    public static FcmDeviceToken managerFcmDeviceToken(String token) {
+        return FcmDeviceToken.builder()
+                .memberKey(MANAGER_KEY)
+                .recipientType(NotificationRecipientType.MANAGER)
+                .token(token)
+                .platform(FcmDevicePlatform.IOS)
+                .build();
+    }
+
+    public static NotificationSendCommand sendCommand() {
+        return new NotificationSendCommand(
+                List.of(GUARDIAN_KEY),
+                List.of(MANAGER_KEY),
+                "title",
+                "body",
+                Map.of("wardKey", WARD_KEY),
+                "SAFE_ZONE_EXIT"
+        );
     }
 }

--- a/src/test/java/com/recaring/notification/implement/FcmDeviceTokenManagerTest.java
+++ b/src/test/java/com/recaring/notification/implement/FcmDeviceTokenManagerTest.java
@@ -1,0 +1,102 @@
+package com.recaring.notification.implement;
+
+import com.recaring.notification.business.command.UpsertFcmDeviceTokenCommand;
+import com.recaring.notification.dataaccess.entity.FcmDevicePlatform;
+import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
+import com.recaring.notification.dataaccess.entity.NotificationRecipientType;
+import com.recaring.notification.dataaccess.repository.FcmDeviceTokenRepository;
+import com.recaring.notification.fixture.NotificationFixture;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FcmDeviceTokenManager unit test")
+class FcmDeviceTokenManagerTest {
+
+    @InjectMocks
+    private FcmDeviceTokenManager fcmDeviceTokenManager;
+
+    @Mock
+    private FcmDeviceTokenRepository fcmDeviceTokenRepository;
+
+    @Test
+    @DisplayName("Registers a new FCM device token")
+    void upsert_saves_new_token_when_absent() {
+        UpsertFcmDeviceTokenCommand command =
+                NotificationFixture.guardianTokenCommand(NotificationFixture.GUARDIAN_FCM_TOKEN);
+        given(fcmDeviceTokenRepository.findByToken(NotificationFixture.GUARDIAN_FCM_TOKEN))
+                .willReturn(Optional.empty());
+        given(fcmDeviceTokenRepository.save(org.mockito.ArgumentMatchers.any(FcmDeviceToken.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        FcmDeviceToken result = fcmDeviceTokenManager.upsert(command);
+
+        assertThat(result.getMemberKey()).isEqualTo(NotificationFixture.GUARDIAN_KEY);
+        assertThat(result.getRecipientType()).isEqualTo(NotificationRecipientType.GUARDIAN);
+        assertThat(result.getPlatform()).isEqualTo(FcmDevicePlatform.ANDROID);
+        assertThat(result.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Reassigns an existing token and reactivates it")
+    void upsert_reassigns_existing_token() {
+        FcmDeviceToken existing = NotificationFixture.guardianFcmDeviceToken(NotificationFixture.GUARDIAN_FCM_TOKEN);
+        existing.deactivate("OLD");
+        UpsertFcmDeviceTokenCommand command = new UpsertFcmDeviceTokenCommand(
+                NotificationFixture.MANAGER_KEY,
+                NotificationRecipientType.MANAGER,
+                NotificationFixture.GUARDIAN_FCM_TOKEN,
+                FcmDevicePlatform.IOS
+        );
+        given(fcmDeviceTokenRepository.findByToken(NotificationFixture.GUARDIAN_FCM_TOKEN))
+                .willReturn(Optional.of(existing));
+
+        FcmDeviceToken result = fcmDeviceTokenManager.upsert(command);
+
+        assertThat(result.getMemberKey()).isEqualTo(NotificationFixture.MANAGER_KEY);
+        assertThat(result.getRecipientType()).isEqualTo(NotificationRecipientType.MANAGER);
+        assertThat(result.getPlatform()).isEqualTo(FcmDevicePlatform.IOS);
+        assertThat(result.isActive()).isTrue();
+        assertThat(result.getDeactivatedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("Deactivates invalid FCM tokens")
+    void deactivateInvalidTokens_deactivates_tokens() {
+        FcmDeviceToken token = NotificationFixture.guardianFcmDeviceToken(NotificationFixture.GUARDIAN_FCM_TOKEN);
+        given(fcmDeviceTokenRepository.findByToken(NotificationFixture.GUARDIAN_FCM_TOKEN))
+                .willReturn(Optional.of(token));
+
+        fcmDeviceTokenManager.deactivateInvalidTokens(List.of(NotificationFixture.GUARDIAN_FCM_TOKEN));
+
+        assertThat(token.isActive()).isFalse();
+        assertThat(token.getDeactivationReason()).isEqualTo("FCM_UNREGISTERED");
+    }
+
+    @Test
+    @DisplayName("Rejects blank FCM tokens")
+    void upsert_rejects_blank_token() {
+        UpsertFcmDeviceTokenCommand command = NotificationFixture.guardianTokenCommand(" ");
+
+        assertThatThrownBy(() -> fcmDeviceTokenManager.upsert(command))
+                .isInstanceOf(AppException.class)
+                .extracting("errorType")
+                .isEqualTo(ErrorType.INVALID_FCM_DEVICE_TOKEN);
+
+        then(fcmDeviceTokenRepository).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/com/recaring/notification/implement/FcmDeviceTokenManagerTest.java
+++ b/src/test/java/com/recaring/notification/implement/FcmDeviceTokenManagerTest.java
@@ -24,7 +24,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("FcmDeviceTokenManager unit test")
+@DisplayName("FCM 디바이스 토큰 매니저 단위 테스트")
 class FcmDeviceTokenManagerTest {
 
     @InjectMocks
@@ -34,7 +34,7 @@ class FcmDeviceTokenManagerTest {
     private FcmDeviceTokenRepository fcmDeviceTokenRepository;
 
     @Test
-    @DisplayName("Registers a new FCM device token")
+    @DisplayName("새 FCM 디바이스 토큰을 등록한다")
     void upsert_saves_new_token_when_absent() {
         UpsertFcmDeviceTokenCommand command =
                 NotificationFixture.guardianTokenCommand(NotificationFixture.GUARDIAN_FCM_TOKEN);
@@ -52,7 +52,7 @@ class FcmDeviceTokenManagerTest {
     }
 
     @Test
-    @DisplayName("Reassigns an existing token and reactivates it")
+    @DisplayName("기존 토큰을 재할당하고 활성화한다")
     void upsert_reassigns_existing_token() {
         FcmDeviceToken existing = NotificationFixture.guardianFcmDeviceToken(NotificationFixture.GUARDIAN_FCM_TOKEN);
         existing.deactivate("OLD");
@@ -75,7 +75,7 @@ class FcmDeviceTokenManagerTest {
     }
 
     @Test
-    @DisplayName("Deactivates invalid FCM tokens")
+    @DisplayName("유효하지 않은 FCM 토큰을 비활성화한다")
     void deactivateInvalidTokens_deactivates_tokens() {
         FcmDeviceToken token = NotificationFixture.guardianFcmDeviceToken(NotificationFixture.GUARDIAN_FCM_TOKEN);
         given(fcmDeviceTokenRepository.findByToken(NotificationFixture.GUARDIAN_FCM_TOKEN))
@@ -88,7 +88,7 @@ class FcmDeviceTokenManagerTest {
     }
 
     @Test
-    @DisplayName("Rejects blank FCM tokens")
+    @DisplayName("빈 FCM 토큰을 거부한다")
     void upsert_rejects_blank_token() {
         UpsertFcmDeviceTokenCommand command = NotificationFixture.guardianTokenCommand(" ");
 
@@ -98,5 +98,17 @@ class FcmDeviceTokenManagerTest {
                 .isEqualTo(ErrorType.INVALID_FCM_DEVICE_TOKEN);
 
         then(fcmDeviceTokenRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("발송에 사용한 FCM 토큰의 마지막 사용 시각을 갱신한다")
+    void touchLastUsedAt_updates_tokens() {
+        FcmDeviceToken token = NotificationFixture.guardianFcmDeviceToken(NotificationFixture.GUARDIAN_FCM_TOKEN);
+        given(fcmDeviceTokenRepository.findAllByTokenIn(List.of(NotificationFixture.GUARDIAN_FCM_TOKEN)))
+                .willReturn(List.of(token));
+
+        fcmDeviceTokenManager.touchLastUsedAt(List.of(NotificationFixture.GUARDIAN_FCM_TOKEN));
+
+        assertThat(token.getLastUsedAt()).isNotNull();
     }
 }

--- a/src/test/java/com/recaring/notification/implement/NotificationDeliveryManagerTest.java
+++ b/src/test/java/com/recaring/notification/implement/NotificationDeliveryManagerTest.java
@@ -1,0 +1,108 @@
+package com.recaring.notification.implement;
+
+import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
+import com.recaring.notification.dataaccess.entity.Notification;
+import com.recaring.notification.dataaccess.entity.NotificationDelivery;
+import com.recaring.notification.dataaccess.entity.NotificationDeliveryStatus;
+import com.recaring.notification.dataaccess.repository.NotificationDeliveryRepository;
+import com.recaring.notification.fixture.NotificationFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotificationDeliveryManager unit test")
+class NotificationDeliveryManagerTest {
+
+    @InjectMocks
+    private NotificationDeliveryManager notificationDeliveryManager;
+
+    @Mock
+    private NotificationDeliveryRepository notificationDeliveryRepository;
+
+    @Test
+    @DisplayName("Creates requested deliveries for tokens")
+    void addRequested_creates_requested_deliveries() {
+        Notification notification = notification();
+        FcmDeviceToken guardianToken =
+                NotificationFixture.guardianFcmDeviceToken(NotificationFixture.GUARDIAN_FCM_TOKEN);
+        List<FcmDeviceToken> tokens = List.of(guardianToken);
+        given(notificationDeliveryRepository.saveAll(org.mockito.ArgumentMatchers.anyList()))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        List<NotificationDelivery> deliveries = notificationDeliveryManager.addRequested(notification, tokens);
+
+        then(notificationDeliveryRepository).should().saveAll(org.mockito.ArgumentMatchers.anyList());
+        assertThat(deliveries).hasSize(1);
+        assertThat(deliveries.getFirst().getStatus()).isEqualTo(NotificationDeliveryStatus.REQUESTED);
+        assertThat(deliveries.getFirst().getTokenSnapshot()).isEqualTo(NotificationFixture.GUARDIAN_FCM_TOKEN);
+    }
+
+    @Test
+    @DisplayName("Applies sent and retryable failed FCM results")
+    void applyResults_marks_sent_and_retryable_failed() {
+        Notification notification = notification();
+        NotificationDelivery sentDelivery = NotificationDelivery.requested(
+                notification,
+                NotificationFixture.guardianFcmDeviceToken(NotificationFixture.GUARDIAN_FCM_TOKEN)
+        );
+        NotificationDelivery failedDelivery = NotificationDelivery.requested(
+                notification,
+                NotificationFixture.managerFcmDeviceToken(NotificationFixture.MANAGER_FCM_TOKEN)
+        );
+        FcmSendResult sendResult = new FcmSendResult(List.of(
+                FcmTokenSendResult.sent(NotificationFixture.GUARDIAN_FCM_TOKEN, "fcm-message-id"),
+                FcmTokenSendResult.failed(NotificationFixture.MANAGER_FCM_TOKEN, "UNAVAILABLE", "temporary", true, false)
+        ));
+
+        notificationDeliveryManager.applyResults(List.of(sentDelivery, failedDelivery), sendResult);
+
+        assertThat(sentDelivery.getStatus()).isEqualTo(NotificationDeliveryStatus.SENT);
+        assertThat(sentDelivery.getFcmMessageId()).isEqualTo("fcm-message-id");
+        assertThat(sentDelivery.isRetryable()).isFalse();
+
+        assertThat(failedDelivery.getStatus()).isEqualTo(NotificationDeliveryStatus.FAILED);
+        assertThat(failedDelivery.getFailureCode()).isEqualTo("UNAVAILABLE");
+        assertThat(failedDelivery.isRetryable()).isTrue();
+        assertThat(failedDelivery.getNextRetryAt()).isAfter(LocalDateTime.now());
+    }
+
+    @Test
+    @DisplayName("Applies non-retryable invalid token FCM result")
+    void applyResults_marks_invalid_token_failed_without_retry() {
+        Notification notification = notification();
+        NotificationDelivery delivery = NotificationDelivery.requested(
+                notification,
+                NotificationFixture.guardianFcmDeviceToken(NotificationFixture.GUARDIAN_FCM_TOKEN)
+        );
+        FcmSendResult sendResult = new FcmSendResult(List.of(
+                FcmTokenSendResult.failed(NotificationFixture.GUARDIAN_FCM_TOKEN, "UNREGISTERED", "gone", false, true)
+        ));
+
+        notificationDeliveryManager.applyResults(List.of(delivery), sendResult);
+
+        assertThat(delivery.getStatus()).isEqualTo(NotificationDeliveryStatus.FAILED);
+        assertThat(delivery.getFailureCode()).isEqualTo("UNREGISTERED");
+        assertThat(delivery.isRetryable()).isFalse();
+        assertThat(delivery.getNextRetryAt()).isNull();
+    }
+
+    private Notification notification() {
+        return Notification.builder()
+                .eventType("SAFE_ZONE_EXIT")
+                .title("title")
+                .body("body")
+                .dataPayload("{}")
+                .build();
+    }
+}

--- a/src/test/java/com/recaring/notification/implement/NotificationDeliveryManagerTest.java
+++ b/src/test/java/com/recaring/notification/implement/NotificationDeliveryManagerTest.java
@@ -21,7 +21,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("NotificationDeliveryManager unit test")
+@DisplayName("알림 전달 매니저 단위 테스트")
 class NotificationDeliveryManagerTest {
 
     @InjectMocks
@@ -31,7 +31,7 @@ class NotificationDeliveryManagerTest {
     private NotificationDeliveryRepository notificationDeliveryRepository;
 
     @Test
-    @DisplayName("Creates requested deliveries for tokens")
+    @DisplayName("토큰별 요청 상태 전달 이력을 생성한다")
     void addRequested_creates_requested_deliveries() {
         Notification notification = notification();
         FcmDeviceToken guardianToken =
@@ -49,7 +49,7 @@ class NotificationDeliveryManagerTest {
     }
 
     @Test
-    @DisplayName("Applies sent and retryable failed FCM results")
+    @DisplayName("성공 및 재시도 가능한 실패 FCM 결과를 반영한다")
     void applyResults_marks_sent_and_retryable_failed() {
         Notification notification = notification();
         NotificationDelivery sentDelivery = NotificationDelivery.requested(
@@ -78,7 +78,7 @@ class NotificationDeliveryManagerTest {
     }
 
     @Test
-    @DisplayName("Applies non-retryable invalid token FCM result")
+    @DisplayName("재시도 불가능한 유효하지 않은 토큰 결과를 반영한다")
     void applyResults_marks_invalid_token_failed_without_retry() {
         Notification notification = notification();
         NotificationDelivery delivery = NotificationDelivery.requested(
@@ -95,6 +95,25 @@ class NotificationDeliveryManagerTest {
         assertThat(delivery.getFailureCode()).isEqualTo("UNREGISTERED");
         assertThat(delivery.isRetryable()).isFalse();
         assertThat(delivery.getNextRetryAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("FCM 결과가 누락되면 기존 시도 횟수에서 증가시킨다")
+    void applyResults_increments_attempt_count_when_result_is_missing() {
+        Notification notification = notification();
+        NotificationDelivery delivery = NotificationDelivery.requested(
+                notification,
+                NotificationFixture.guardianFcmDeviceToken(NotificationFixture.GUARDIAN_FCM_TOKEN)
+        );
+        delivery.markFailed("OLD_FAILURE", "old failure", 2, true, LocalDateTime.now());
+        FcmSendResult sendResult = new FcmSendResult(List.of());
+
+        notificationDeliveryManager.applyResults(List.of(delivery), sendResult);
+
+        assertThat(delivery.getStatus()).isEqualTo(NotificationDeliveryStatus.FAILED);
+        assertThat(delivery.getFailureCode()).isEqualTo("MISSING_FCM_RESULT");
+        assertThat(delivery.getAttemptCount()).isEqualTo(3);
+        assertThat(delivery.isRetryable()).isTrue();
     }
 
     private Notification notification() {

--- a/src/test/java/com/recaring/notification/implement/NotificationPayloadSerializerTest.java
+++ b/src/test/java/com/recaring/notification/implement/NotificationPayloadSerializerTest.java
@@ -1,0 +1,60 @@
+package com.recaring.notification.implement;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.recaring.notification.fixture.NotificationFixture;
+import com.recaring.support.exception.AppException;
+import com.recaring.support.exception.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("알림 payload 직렬화 단위 테스트")
+class NotificationPayloadSerializerTest {
+
+    @InjectMocks
+    private NotificationPayloadSerializer notificationPayloadSerializer;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("payload를 JSON 문자열로 직렬화한다")
+    void serialize_returns_json() throws JsonProcessingException {
+        Map<String, String> payload = Map.of("wardKey", NotificationFixture.WARD_KEY);
+        given(objectMapper.writeValueAsString(payload)).willReturn("{\"wardKey\":\"ward-member-key-001\"}");
+
+        String result = notificationPayloadSerializer.serialize(payload);
+
+        assertThat(result).isEqualTo("{\"wardKey\":\"ward-member-key-001\"}");
+    }
+
+    @Test
+    @DisplayName("직렬화에 실패하면 원인을 보존한 AppException을 던진다")
+    void serialize_throws_app_exception_with_cause() throws JsonProcessingException {
+        Map<String, String> payload = Map.of("wardKey", NotificationFixture.WARD_KEY);
+        JsonProcessingException cause = new JsonProcessingException("serialize failed") {
+        };
+        given(objectMapper.writeValueAsString(payload)).willThrow(cause);
+
+        assertThatThrownBy(() -> notificationPayloadSerializer.serialize(payload))
+                .isInstanceOf(AppException.class)
+                .satisfies(exception -> {
+                    AppException appException = (AppException) exception;
+                    assertThat(appException.getErrorType())
+                            .isEqualTo(ErrorType.NOTIFICATION_PAYLOAD_SERIALIZATION_FAILED);
+                    assertThat(appException.getCause()).isSameAs(cause);
+                    assertThat(appException.getData()).isNull();
+                });
+    }
+}

--- a/src/test/java/com/recaring/notification/implement/NotificationWriterTest.java
+++ b/src/test/java/com/recaring/notification/implement/NotificationWriterTest.java
@@ -1,0 +1,102 @@
+package com.recaring.notification.implement;
+
+import com.recaring.notification.dataaccess.entity.FcmDeviceToken;
+import com.recaring.notification.dataaccess.entity.Notification;
+import com.recaring.notification.dataaccess.entity.NotificationDelivery;
+import com.recaring.notification.dataaccess.entity.NotificationStatus;
+import com.recaring.notification.dataaccess.repository.NotificationRepository;
+import com.recaring.notification.fixture.NotificationFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("알림 Writer 단위 테스트")
+class NotificationWriterTest {
+
+    @InjectMocks
+    private NotificationWriter notificationWriter;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Test
+    @DisplayName("활성 토큰이 없으면 알림 실패 상태를 저장한다")
+    void markFailedForNoActiveToken_saves_failed_notification() {
+        Notification notification = notification();
+
+        notificationWriter.markFailedForNoActiveToken(notification);
+
+        assertThat(notification.getStatus()).isEqualTo(NotificationStatus.FAILED);
+        assertThat(notification.getFailureCode()).isEqualTo("NO_ACTIVE_TOKEN");
+        then(notificationRepository).should().save(notification);
+    }
+
+    @Test
+    @DisplayName("모든 전달이 성공하면 알림 성공 상태를 저장한다")
+    void completeByDeliveries_saves_sent_notification() {
+        Notification notification = notification();
+        NotificationDelivery delivery = delivery(notification);
+        delivery.markSent("message-id", 1);
+
+        notificationWriter.completeByDeliveries(notification, List.of(delivery));
+
+        assertThat(notification.getStatus()).isEqualTo(NotificationStatus.SENT);
+        then(notificationRepository).should().save(notification);
+    }
+
+    @Test
+    @DisplayName("일부 전달만 성공하면 알림 부분 성공 상태를 저장한다")
+    void completeByDeliveries_saves_partial_notification() {
+        Notification notification = notification();
+        NotificationDelivery sentDelivery = delivery(notification);
+        NotificationDelivery failedDelivery = NotificationDelivery.requested(
+                notification,
+                NotificationFixture.managerFcmDeviceToken(NotificationFixture.MANAGER_FCM_TOKEN)
+        );
+        sentDelivery.markSent("message-id", 1);
+        failedDelivery.markFailed("UNAVAILABLE", "temporary", 1, true, null);
+
+        notificationWriter.completeByDeliveries(notification, List.of(sentDelivery, failedDelivery));
+
+        assertThat(notification.getStatus()).isEqualTo(NotificationStatus.PARTIAL);
+        assertThat(notification.getFailureCode()).isEqualTo("DELIVERY_FAILED");
+        then(notificationRepository).should().save(notification);
+    }
+
+    @Test
+    @DisplayName("모든 전달이 실패하면 알림 실패 상태를 저장한다")
+    void completeByDeliveries_saves_failed_notification() {
+        Notification notification = notification();
+        NotificationDelivery delivery = delivery(notification);
+        delivery.markFailed("UNAVAILABLE", "temporary", 1, true, null);
+
+        notificationWriter.completeByDeliveries(notification, List.of(delivery));
+
+        assertThat(notification.getStatus()).isEqualTo(NotificationStatus.FAILED);
+        assertThat(notification.getFailureCode()).isEqualTo("DELIVERY_FAILED");
+        then(notificationRepository).should().save(notification);
+    }
+
+    private Notification notification() {
+        return Notification.builder()
+                .eventType("SAFE_ZONE_EXIT")
+                .title("title")
+                .body("body")
+                .dataPayload("{}")
+                .build();
+    }
+
+    private NotificationDelivery delivery(Notification notification) {
+        FcmDeviceToken token = NotificationFixture.guardianFcmDeviceToken(NotificationFixture.GUARDIAN_FCM_TOKEN);
+        return NotificationDelivery.requested(notification, token);
+    }
+}

--- a/src/test/java/com/recaring/support/IntegrationTest.java
+++ b/src/test/java/com/recaring/support/IntegrationTest.java
@@ -1,5 +1,6 @@
 package com.recaring.support;
 
+import com.recaring.RecaringApplication;
 import org.junit.jupiter.api.Tag;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -11,6 +12,6 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Tag("integration")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = RecaringApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public @interface IntegrationTest {
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
## Summary
- Add FCM device token upsert API for guardian/manager recipients.
- Add Firebase Admin configuration with a no-op client fallback when Firebase is disabled.
- Add notification send workflow with notification/delivery persistence, FCM result handling, invalid token deactivation, and delivery summary result.
- Add ST-004 DDL for FCM device tokens, notifications, and notification deliveries.

## Tests
- PASS: `./gradlew.bat test --tests com.recaring.notification.*`
- FAIL: `./gradlew.bat test` currently fails in `GpsHistoryRepositoryTest` during Testcontainers initialization because the local Windows Testcontainers/Docker path config includes `>SETX PATH C:\Program Files\MySQL\MySQL Server 8.4\bin`, which is parsed as an invalid path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * FCM 푸시 알림 전송 기능 추가 및 보호자/매니저 대상 배송 지원
  * 기기 토큰 등록/관리 API 추가 (PUT /api/v1/notifications/device-tokens) — 보호자 권한으로 보호

* **Documentation**
  * 알림 전달 관련 데이터베이스 스키마(테이블·인덱스) 문서화

* **Tests**
  * 알림 전송 및 토큰 관리 관련 통합·단위 테스트 대거 추가

* **Chores**
  * Firebase Admin SDK 의존성 및 환경설정 항목 추가 (베이스64 서비스계정)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/brian506/re-caring/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->